### PR TITLE
Release v0.0.4

### DIFF
--- a/.github/workflows/deploy-image.yaml
+++ b/.github/workflows/deploy-image.yaml
@@ -23,8 +23,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:

--- a/charts/cdn-origin-controller/Chart.yaml
+++ b/charts/cdn-origin-controller/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.0.3"
+appVersion: "v0.0.4"
 description: The cdn-origin-controller Helm Chart
 name: cdn-origin-controller
-version: v0.0.2
+version: v0.0.3

--- a/charts/cdn-origin-controller/values.yaml
+++ b/charts/cdn-origin-controller/values.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/gympass/cdn-origin-controller
-  tag: "0.0.3"
-  pullPolicy: Always
+  tag: v0.0.4
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Changelog:
  - use "v" prefix on image tags ([ref](https://github.com/docker/metadata-action#typesemver))
  - bump chart version to `v0.0.3` and image version to `v0.0.4`