### PR TITLE
[RN-244] Implement annotation to configure CF viewer request function association

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The controller will look for three locations within the Ingress definition in or
 The following annotation controls how origins and behaviors are attached to existing CloudFront distributions:
 
   - `cdn-origin-controller.gympass.com/cdn.id`: the ID of the CloudFront distribution where the origins and behaviors should be present. Example: `cdn-origin-controller.gympass.com/cdn.id: E7IQHB92RC62FG`
+  - `cdn-origin-controller.gympass.com/cf.viewer-function-arn`: the ARN of the CloudFront function you would like to associate to viewer requests in each behavior managed by this Ingress. Example: `arn:aws:cloudfront::000000000000:function/my-function`
 
 The controller needs permission to manipulate the CloudFront distributions. A [sample IAM Policy](docs/iam_policy.json) is provided with the necessary IAM actions.
 

--- a/controllers/cloudfront.go
+++ b/controllers/cloudfront.go
@@ -30,7 +30,7 @@ import (
 const prefixPathType = string(networkingv1beta1.PathTypePrefix)
 
 func newOrigin(dto ingressDTO) cloudfront.Origin {
-	builder := cloudfront.NewOriginBuilder(dto.host)
+	builder := cloudfront.NewOriginBuilder(dto.host).WithViewerFunction(dto.viewerFnARN)
 	patterns := pathPatterns(dto.paths)
 	for _, p := range patterns {
 		builder = builder.WithBehavior(p)

--- a/controllers/ingress_dto.go
+++ b/controllers/ingress_dto.go
@@ -35,8 +35,9 @@ type path struct {
 }
 
 type ingressDTO struct {
-	host  string
-	paths []path
+	host        string
+	paths       []path
+	viewerFnARN string
 }
 
 func newIngressDTO(obj client.Object) (ingressDTO, error) {
@@ -51,8 +52,9 @@ func newIngressDTO(obj client.Object) (ingressDTO, error) {
 
 func newIngressDTOV1beta1(ing *networkingv1beta1.Ingress) ingressDTO {
 	return ingressDTO{
-		host:  ing.Status.LoadBalancer.Ingress[0].Hostname,
-		paths: pathsV1beta1(ing.Spec.Rules),
+		host:        ing.Status.LoadBalancer.Ingress[0].Hostname,
+		paths:       pathsV1beta1(ing.Spec.Rules),
+		viewerFnARN: viewerFnARN(ing),
 	}
 }
 
@@ -72,8 +74,9 @@ func pathsV1beta1(rules []networkingv1beta1.IngressRule) []path {
 
 func newIngressDTOV1(ing *networkingv1.Ingress) ingressDTO {
 	return ingressDTO{
-		host:  ing.Status.LoadBalancer.Ingress[0].Hostname,
-		paths: pathsV1(ing.Spec.Rules),
+		host:        ing.Status.LoadBalancer.Ingress[0].Hostname,
+		paths:       pathsV1(ing.Spec.Rules),
+		viewerFnARN: viewerFnARN(ing),
 	}
 }
 
@@ -89,4 +92,8 @@ func pathsV1(rules []networkingv1.IngressRule) []path {
 		}
 	}
 	return paths
+}
+
+func viewerFnARN(obj client.Object) string {
+	return obj.GetAnnotations()[cfViewerFnAnnotation]
 }

--- a/controllers/ingress_reconciler.go
+++ b/controllers/ingress_reconciler.go
@@ -30,7 +30,10 @@ import (
 	"github.com/Gympass/cdn-origin-controller/internal/cloudfront"
 )
 
-const cdnIDAnnotation = "cdn-origin-controller.gympass.com/cdn.id"
+const (
+	cdnIDAnnotation      = "cdn-origin-controller.gympass.com/cdn.id"
+	cfViewerFnAnnotation = "cdn-origin-controller.gympass.com/cf.viewer-function-arn"
+)
 
 const (
 	attachOriginFailedReason  = "FailedToAttach"

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -19,35 +19,46 @@
 
 package cloudfront
 
+// Origin represents a CloudFront Origin and aggregates Behaviors associated with it
 type Origin struct {
-	Host      string
+	// Host is the origin's hostname
+	Host string
+	// Behaviors is the collection of Behaviors associated with this Origin
 	Behaviors []Behavior
 }
 
+// Behavior represents a CloudFront Cache Behavior
 type Behavior struct {
+	// PathPattern is the path pattern used when configuring the Behavior
 	PathPattern string
+	// ViewerFnARN is the ARN of the function to be associated with the Behavior's viewer requests
 	ViewerFnARN string
 }
 
+// OriginBuilder allows the construction of a Origin
 type OriginBuilder struct {
 	origin      Origin
 	viewerFnARN string
 }
 
+// NewOriginBuilder returns an OriginBuilder for a given host
 func NewOriginBuilder(host string) OriginBuilder {
 	return OriginBuilder{origin: Origin{Host: host}}
 }
 
+// WithBehavior adds a Behavior to the Origin being built given a path pattern the Behavior should respond for
 func (b OriginBuilder) WithBehavior(pathPattern string) OriginBuilder {
 	b.origin.Behaviors = append(b.origin.Behaviors, Behavior{PathPattern: pathPattern})
 	return b
 }
 
+// WithViewerFunction associates a function with all viewer requests of all Behaviors in the Origin being build
 func (b OriginBuilder) WithViewerFunction(fnARN string) OriginBuilder {
 	b.viewerFnARN = fnARN
 	return b
 }
 
+// Build creates an Origin based on configuration made so far
 func (b OriginBuilder) Build() Origin {
 	if len(b.viewerFnARN) > 0 {
 		b.addViewerFnToBehaviors()

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -52,7 +52,7 @@ func (b OriginBuilder) WithBehavior(pathPattern string) OriginBuilder {
 	return b
 }
 
-// WithViewerFunction associates a function with all viewer requests of all Behaviors in the Origin being build
+// WithViewerFunction associates a function with all viewer requests of all Behaviors in the Origin being built
 func (b OriginBuilder) WithViewerFunction(fnARN string) OriginBuilder {
 	b.viewerFnARN = fnARN
 	return b

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -26,10 +26,12 @@ type Origin struct {
 
 type Behavior struct {
 	PathPattern string
+	ViewerFnARN string
 }
 
 type OriginBuilder struct {
-	origin Origin
+	origin      Origin
+	viewerFnARN string
 }
 
 func NewOriginBuilder(host string) OriginBuilder {
@@ -41,6 +43,20 @@ func (b OriginBuilder) WithBehavior(pathPattern string) OriginBuilder {
 	return b
 }
 
+func (b OriginBuilder) WithViewerFunction(fnARN string) OriginBuilder {
+	b.viewerFnARN = fnARN
+	return b
+}
+
 func (b OriginBuilder) Build() Origin {
+	if len(b.viewerFnARN) > 0 {
+		b.addViewerFnToBehaviors()
+	}
 	return b.origin
+}
+
+func (b OriginBuilder) addViewerFnToBehaviors() {
+	for i := range b.origin.Behaviors {
+		b.origin.Behaviors[i].ViewerFnARN = b.viewerFnARN
+	}
 }

--- a/internal/cloudfront/origin_test.go
+++ b/internal/cloudfront/origin_test.go
@@ -36,9 +36,33 @@ type OriginTestSuite struct {
 	suite.Suite
 }
 
-func (s *OriginTestSuite) TestNewOriginBuilder_SingleOriginAndBehavior() {
+func (s *OriginTestSuite) TestNewOriginBuilder_SingleBehavior() {
 	o := cloudfront.NewOriginBuilder("origin").WithBehavior("/*").Build()
 	s.Equal("origin", o.Host)
 	s.Len(o.Behaviors, 1)
 	s.Equal("/*", o.Behaviors[0].PathPattern)
+}
+
+func (s *OriginTestSuite) TestNewOriginBuilder_MultipleBehaviors() {
+	o := cloudfront.NewOriginBuilder("origin").
+		WithBehavior("/*").
+		WithBehavior("/foo").
+		WithBehavior("/bar").
+		Build()
+	s.Equal("origin", o.Host)
+	s.Len(o.Behaviors, 3)
+	s.Equal("/*", o.Behaviors[0].PathPattern)
+	s.Equal("/foo", o.Behaviors[1].PathPattern)
+	s.Equal("/bar", o.Behaviors[2].PathPattern)
+}
+
+func (s *OriginTestSuite) TestNewOriginBuilder_ViewerFunction() {
+	o := cloudfront.NewOriginBuilder("origin").
+		WithBehavior("/").
+		WithViewerFunction("some-arn").
+		Build()
+	s.Equal("origin", o.Host)
+	s.Len(o.Behaviors, 1)
+	s.Equal("/", o.Behaviors[0].PathPattern)
+	s.Equal("some-arn", o.Behaviors[0].ViewerFnARN)
 }


### PR DESCRIPTION
All behaviors generated from the Ingress resource will share the same function. When this is unwanted it's advised to split the Ingress configuration into multiple  resources, each with their own configuration for this.

Signed-off-by: Lucas Caparelli <lucas.caparelli@gympass.com>