### PR TITLE
[RN-291] Support removal of Ingresses and deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ bin/
 .idea/
 
 .env
+
+# files for demoing the controller
+demo/

--- a/Makefile
+++ b/Makefile
@@ -209,3 +209,6 @@ add-headers:
 
 mod-tidy:
 	go mod tidy 
+
+test-cov: test
+	go tool cover -html=cover.out

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The controller will look for three locations within the Ingress definition in or
 The following annotation controls how origins and behaviors are attached to CloudFront distributions:
 
 - `cdn-origin-controller.gympass.com/cdn.group`: a CDN group should be used to bind Ingress resources together under the same distribution. If the group does not exist yet a new distribution will be provisioned. Example: `cdn-origin-controller.gympass.com/cdn.group: customer-portal`
+- `cdn-origin-controller.gympass.com/cf.alternate-domain-names`: a comma-separated list of alternate domains to be configured on the CloudFront distribution. Duplicates on the same or different Ingress resources from the same group cause no harm. Example: `alias1.foo,alias2.foo`
+- `cdn-origin-controller.gympass.com/cf.origin-response-timeout`: the number of seconds that CloudFront waits for a response from the origin, from 1 to 60. Example: `"30"`
 - `cdn-origin-controller.gympass.com/cf.viewer-function-arn`: the ARN of the CloudFront function you would like to associate to viewer requests in each behavior managed by this Ingress. Example: `arn:aws:cloudfront::000000000000:function/my-function`
-- `cdn-origin-controller.gympass.com/cf.origin-response-timeout`: the number of seconds that CloudFront waits for a response from the origin, from 1 to 60. Example: `30`
 
 The controller needs permission to manipulate the CloudFront distributions. A [sample IAM Policy](docs/iam_policy.json) is provided with the necessary IAM actions.
 

--- a/api/v1alpha1/cdnstatus_types.go
+++ b/api/v1alpha1/cdnstatus_types.go
@@ -101,12 +101,12 @@ func (c *CDNStatus) RemoveDNSRecords(records []string) {
 }
 
 // SetIngressRef set IngressRef to the status based on Ingress obj
-func (c *CDNStatus) SetIngressRef(inSync bool, obj namespacedName) {
+func (c *CDNStatus) SetIngressRef(inSync bool, ing namespacedName) {
 	if c.Status.Ingresses == nil {
 		c.Status.Ingresses = make(IngressRefs)
 	}
 
-	ref := NewIngressRef(obj.GetNamespace(), obj.GetName())
+	ref := NewIngressRef(ing.GetNamespace(), ing.GetName())
 
 	status := syncedIngressStatus
 	if !inSync {
@@ -114,6 +114,25 @@ func (c *CDNStatus) SetIngressRef(inSync bool, obj namespacedName) {
 	}
 
 	c.Status.Ingresses[ref] = status
+}
+
+// RemoveIngressRef ensures the given Ingress is not referenced
+func (c *CDNStatus) RemoveIngressRef(ing namespacedName) {
+	if c.Status.Ingresses == nil {
+		return
+	}
+	ref := NewIngressRef(ing.GetNamespace(), ing.GetName())
+	delete(c.Status.Ingresses, ref)
+}
+
+// HasIngressRef returns whether the given Ingress is part of the refs stored by CDNStatus
+func (c *CDNStatus) HasIngressRef(ing namespacedName) bool {
+	if c.Status.Ingresses == nil {
+		return false
+	}
+	ref := NewIngressRef(ing.GetNamespace(), ing.GetName())
+	_, ok := c.Status.Ingresses[ref]
+	return ok
 }
 
 // GetIngressKeys returns keys to manipulate all IngressRef stored in the CDNStatus

--- a/api/v1alpha1/cdnstatus_types_test.go
+++ b/api/v1alpha1/cdnstatus_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +21,7 @@ type CDNStatusTestSuite struct {
 
 func (s *CDNStatusTestSuite) Test_SetIngressRef_IngressAlreadyExists() {
 	key := IngressRef("namespace/name")
-	cdnStatus := CDNStatus{
+	cdnStatus := &CDNStatus{
 		Status: CDNStatusStatus{
 			Ingresses: IngressRefs{
 				key: failedIngressStatus,
@@ -36,7 +37,7 @@ func (s *CDNStatusTestSuite) Test_SetIngressRef_IngressAlreadyExists() {
 }
 
 func (s *CDNStatusTestSuite) Test_SetIngressRef_AddFirstIngress() {
-	cdnStatus := CDNStatus{}
+	cdnStatus := &CDNStatus{}
 
 	nsName := &metav1.ObjectMeta{Namespace: "bar", Name: "foo"}
 	cdnStatus.SetIngressRef(true, nsName)
@@ -49,7 +50,7 @@ func (s *CDNStatusTestSuite) Test_SetIngressRef_AddFirstIngress() {
 
 func (s *CDNStatusTestSuite) Test_SetIngressRef_AddNewIngressToExistingIngresses() {
 	existingKey := IngressRef("namespace/name")
-	cdnStatus := CDNStatus{
+	cdnStatus := &CDNStatus{
 		Status: CDNStatusStatus{
 			Ingresses: IngressRefs{
 				existingKey: failedIngressStatus,
@@ -67,20 +68,61 @@ func (s *CDNStatusTestSuite) Test_SetIngressRef_AddNewIngressToExistingIngresses
 	s.Equal(syncedIngressStatus, cdnStatus.Status.Ingresses[newKey])
 }
 
+func (s *CDNStatusTestSuite) Test_DeleteIngresRef_NoRefsExist() {
+	status := &CDNStatus{}
+	ing := &networkingv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+
+	status.RemoveIngressRef(ing)
+
+	ref := NewIngressRef(ing.Namespace, ing.Name)
+	_, ok := status.Status.Ingresses[ref]
+	s.False(ok)
+}
+
+func (s *CDNStatusTestSuite) Test_DeleteIngresRef_RefsExistButNotTheOneBeingRemoved() {
+	status := &CDNStatus{Status: CDNStatusStatus{Ingresses: IngressRefs{
+		"namespace/name": failedIngressStatus,
+	}}}
+	ing := &networkingv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+
+	status.RemoveIngressRef(ing)
+
+	ref := NewIngressRef(ing.Namespace, ing.Name)
+	_, ok := status.Status.Ingresses[ref]
+	s.False(ok)
+}
+
+func (s *CDNStatusTestSuite) Test_DeleteIngresRef_RefBeingRemovedExists() {
+	status := &CDNStatus{Status: CDNStatusStatus{Ingresses: IngressRefs{
+		"foo/bar": failedIngressStatus,
+	}}}
+	ing := &networkingv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+
+	ref := NewIngressRef(ing.Namespace, ing.Name)
+	refStatus, ok := status.Status.Ingresses[ref]
+	s.True(ok)
+	s.Equal(failedIngressStatus, refStatus)
+
+	status.RemoveIngressRef(ing)
+
+	_, ok = status.Status.Ingresses[ref]
+	s.False(ok)
+}
+
 func (s *CDNStatusTestSuite) Test_GetIngressKeys() {
 	testCases := []struct {
 		name      string
-		cdnStatus CDNStatus
+		cdnStatus *CDNStatus
 		want      []client.ObjectKey
 	}{
 		{
 			name:      "No Ingresses",
-			cdnStatus: CDNStatus{},
+			cdnStatus: &CDNStatus{},
 			want:      nil,
 		},
 		{
 			name: "Two Ingresses",
-			cdnStatus: CDNStatus{
+			cdnStatus: &CDNStatus{
 				Status: CDNStatusStatus{
 					Ingresses: IngressRefs{
 						"bar/foo": failedIngressStatus,

--- a/charts/cdn-origin-controller/templates/role.yaml
+++ b/charts/cdn-origin-controller/templates/role.yaml
@@ -19,3 +19,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/finalizers
+  verbs:
+  - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,3 +21,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/finalizers
+  verbs:
+  - update

--- a/config/samples/multiple_ing_same_group.yaml
+++ b/config/samples/multiple_ing_same_group.yaml
@@ -1,0 +1,41 @@
+# these ingresses compose a single CloudFront distribution
+# each configures an alias as well, via the cdn-origin-controller.gympass.com/cf.alternate-domain-names annotation
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: foo1
+  annotations:
+    cdn-origin-controller.gympass.com/cdn.group: "foo"
+    cdn-origin-controller.gympass.com/cf.alternate-domain-names: "alias-foo1.bar"
+spec:
+  rules:
+    - host: foo1.bar
+      http:
+        paths:
+          - path: /testpath1
+            pathType: Prefix
+            backend:
+              service:
+                name: test
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: foo2
+  annotations:
+    cdn-origin-controller.gympass.com/cdn.group: "foo"
+    cdn-origin-controller.gympass.com/cf.alternate-domain-names: "alias-foo2.bar"
+spec:
+  rules:
+    - host: foo2.bar
+      http:
+        paths:
+          - path: /testpath2
+            pathType: Prefix
+            backend:
+              service:
+                name: test
+                port:
+                  number: 80

--- a/controllers/ingress_reconciler.go
+++ b/controllers/ingress_reconciler.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -42,6 +43,7 @@ import (
 )
 
 const (
+	cdnFinalizer                     = "cdn-origin-controller.gympass.com/finalizer"
 	cdnGroupAnnotation               = "cdn-origin-controller.gympass.com/cdn.group"
 	cfViewerFnAnnotation             = "cdn-origin-controller.gympass.com/cf.viewer-function-arn"
 	cfOrigRespTimeoutAnnotation      = "cdn-origin-controller.gympass.com/cf.origin-response-timeout"
@@ -53,7 +55,7 @@ const (
 	reasonSuccess = "SuccessfullyReconciled"
 )
 
-var errNoAnnotation = errors.New(cdnGroupAnnotation + " annotation not present")
+var noCDNStatusForIngErr = errors.New("could not find a CDNStatus that referenced the ingress")
 
 type boundIngressesFunc func(v1alpha1.CDNStatus) ([]ingressParams, error)
 
@@ -72,59 +74,153 @@ type IngressReconciler struct {
 
 // Reconcile an Ingress resource of any version
 func (r *IngressReconciler) Reconcile(reconciling ingressParams, obj client.Object) error {
-	dist := newDistribution(newOrigin(reconciling), reconciling, r.Config)
+	var ingresses []ingressParams
 
-	var errs *multierror.Error
-	var reconciliationErr error
-	nsName := types.NamespacedName{Name: reconciling.group}
-	cdnStatus := &v1alpha1.CDNStatus{}
-	err := r.Get(context.Background(), nsName, cdnStatus)
+	isRemovingReconciling := isRemoving(obj)
+	if !isRemovingReconciling {
+		ingresses = append(ingresses, reconciling)
+	}
 
-	shouldCreate := k8serrors.IsNotFound(err)
-	shouldSync := err == nil
+	cdnStatus, fetchStatusErr := r.fetchCDNStatus(obj)
+	if errors.Is(fetchStatusErr, noCDNStatusForIngErr) {
+		r.log.Error(fmt.Errorf("fetching CDNStatus: %v", fetchStatusErr), "CDNStatus not found for Ingress which has no group annotation but has finalizer. Removing finalizer. State may be inconsistent.")
+		shouldHaveFinalizer := false
+		return r.reconcileFinalizer(obj, shouldHaveFinalizer)
+	}
 
-	switch {
-	case shouldCreate:
-		dist, reconciliationErr = r.createDistribution(dist, reconciling.group)
-		errs = multierror.Append(errs, reconciliationErr)
-
-		cdnStatus, err = r.createCDNStatus(dist, reconciling.group)
+	foundStatus := fetchStatusErr == nil
+	if foundStatus {
+		r.log.V(1).Info("CDNStatus resource found.", "cdnStatusName", cdnStatus.Name)
+		boundIngresses, err := r.BoundIngressParamsFn(filterIngressRef(cdnStatus, obj))
 		if err != nil {
-			errs = multierror.Append(errs, err)
-			return fmt.Errorf("creating CDNStatus: %v", errs.ErrorOrNil())
+			return err
 		}
-	case shouldSync:
-		dist, reconciliationErr = r.syncDistribution(cdnStatus, obj, dist)
-		errs = multierror.Append(errs, reconciliationErr)
-	default:
-		return fmt.Errorf("fetching CDN status: %v", err)
+		ingresses = append(ingresses, boundIngresses...)
+
+		if isRemovingReconciling {
+			cdnStatus.RemoveIngressRef(obj)
+		}
 	}
 
-	inSync := true
-	if errs.Len() > 0 {
-		inSync = false
+	group := cdnStatus.Name
+	if !foundStatus {
+		group = reconciling.group
 	}
-	cdnStatus.SetIngressRef(inSync, obj)
+
+	var distErr error
+	var dist cloudfront.Distribution
+	errs := &multierror.Error{}
+	distBuilder := newDistributionBuilder(ingresses, group, r.Config)
+
+	shouldCreateDist := k8serrors.IsNotFound(fetchStatusErr)
+	shouldDeleteDist := len(ingresses) == 0
+	shouldSyncDist := foundStatus && !shouldDeleteDist
+	switch {
+	case shouldCreateDist:
+		dist, distErr = r.createDistribution(r.build(distBuilder), group)
+		if distErr != nil {
+			return fmt.Errorf("creating distribution: %v", distErr)
+		}
+
+		cdnStatus, distErr = r.createCDNStatus(dist, reconciling.group)
+		if distErr != nil {
+			return fmt.Errorf("creating CDNStatus: %v", distErr)
+		}
+	case shouldSyncDist:
+		dist, distErr = r.syncDistribution(cdnStatus, distBuilder)
+		errs = multierror.Append(errs, distErr)
+	case shouldDeleteDist:
+		dist, distErr = r.deleteDistribution(cdnStatus, distBuilder)
+		errs = multierror.Append(errs, distErr)
+	default:
+		return fmt.Errorf("fetching CDN status: %v", fetchStatusErr)
+	}
+
+	if !isRemovingReconciling {
+		inSync := true
+		if errs.Len() > 0 {
+			inSync = false
+		}
+		cdnStatus.SetIngressRef(inSync, obj)
+	}
 	cdnStatus.SetAliases(dist.AlternateDomains)
 
+	var aliasesErr error
 	if r.Config.CloudFrontRoute53CreateAlias {
-		err := r.syncAliases(cdnStatus, dist)
-		errs = multierror.Append(errs, err)
+		aliasesErr = r.syncAliases(cdnStatus, dist)
+		errs = multierror.Append(errs, aliasesErr)
 	}
 
-	return r.handleResult(obj, cdnStatus, errs)
+	reconciledSomething := distErr == nil || aliasesErr == nil
+	shouldHaveFinalizer := hasFinalizer(obj) || reconciledSomething
+	if isRemovingReconciling {
+		shouldHaveFinalizer = errs.Len() > 0
+	}
+	return r.handleResult(obj, cdnStatus, shouldHaveFinalizer, errs)
 }
 
-func (r *IngressReconciler) handleResult(obj client.Object, cdnStatus *v1alpha1.CDNStatus, errs *multierror.Error) error {
-	if err := r.updateCDNStatus(cdnStatus); err != nil {
-		errs = multierror.Append(errs, err)
+func (r *IngressReconciler) fetchCDNStatus(ing client.Object) (*v1alpha1.CDNStatus, error) {
+	if isRemoving(ing) && !hasGroupAnnotation(ing) {
+		return r.discoverCDNStatusForIngress(ing)
+	}
+
+	nsName := types.NamespacedName{Name: ing.GetAnnotations()[cdnGroupAnnotation]}
+	cdnStatus := &v1alpha1.CDNStatus{}
+	fetchStatusErr := r.Get(context.Background(), nsName, cdnStatus)
+	return cdnStatus, fetchStatusErr
+}
+
+func (r *IngressReconciler) discoverCDNStatusForIngress(ing client.Object) (*v1alpha1.CDNStatus, error) {
+	statusList := &v1alpha1.CDNStatusList{}
+	if err := r.Client.List(context.Background(), statusList); err != nil {
+		return nil, fmt.Errorf("listing CDNStatus resources: %v", err)
+	}
+
+	for _, s := range statusList.Items {
+		if s.HasIngressRef(ing) {
+			return &s, nil
+		}
+	}
+	return nil, fmt.Errorf("trying to match Ingress (%s/%s): %w", ing.GetNamespace(), ing.GetName(), noCDNStatusForIngErr)
+}
+
+func (r *IngressReconciler) handleResult(obj client.Object, cdnStatus *v1alpha1.CDNStatus, shouldHaveFinalizer bool, errs *multierror.Error) error {
+	err := r.reconcileStatus(cdnStatus)
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("reconciling CDNStatus: %v", err))
+	}
+	err = r.reconcileFinalizer(obj, shouldHaveFinalizer)
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("reconciling finalizer: %v", err))
 	}
 
 	if errs.Len() > 0 {
 		return r.handleFailure(errs, obj, cdnStatus)
 	}
-
 	return r.handleSuccess(obj, cdnStatus)
+}
+
+func (r *IngressReconciler) reconcileStatus(cdnStatus *v1alpha1.CDNStatus) error {
+	if len(cdnStatus.Status.Ingresses) == 0 {
+		if err := r.Delete(context.Background(), cdnStatus); err != nil {
+			r.log.Error(err, "Could not delete CDNStatus resource", "cdnStatus", cdnStatus)
+			return err
+		}
+	}
+	if err := r.updateCDNStatus(cdnStatus); err != nil {
+		r.log.Error(err, "Could not persist CDNStatus resource", "cdnStatus", cdnStatus)
+		return err
+	}
+	return nil
+}
+
+func (r *IngressReconciler) reconcileFinalizer(obj client.Object, shouldHaveFinalizer bool) error {
+	if shouldHaveFinalizer {
+		controllerutil.AddFinalizer(obj, cdnFinalizer)
+	} else {
+		controllerutil.RemoveFinalizer(obj, cdnFinalizer)
+	}
+	return r.Client.Update(context.Background(), obj)
 }
 
 func (r *IngressReconciler) syncAliases(cdnStatus *v1alpha1.CDNStatus, dist cloudfront.Distribution) error {
@@ -151,27 +247,7 @@ func (r *IngressReconciler) syncAliases(cdnStatus *v1alpha1.CDNStatus, dist clou
 	return result.ErrorOrNil()
 }
 
-func (r *IngressReconciler) syncDistribution(cdnStatus *v1alpha1.CDNStatus, obj client.Object, dist cloudfront.Distribution) (cloudfront.Distribution, error) {
-	r.log.V(1).Info("CDNStatus resource found.", "cdnStatusName", cdnStatus.Name)
-	boundIngressesParams, err := r.BoundIngressParamsFn(filterIngressRef(cdnStatus, obj))
-	if err != nil {
-		return dist, err
-	}
-	for _, ip := range boundIngressesParams {
-		dist.AddOrigin(newOrigin(ip))
-		dist.AddAlternateDomains(ip.alternateDomainNames)
-	}
-
-	dist.ID = cdnStatus.Status.ID
-	dist.ARN = cdnStatus.Status.ARN
-	dist.Address = cdnStatus.Status.Address
-	r.log.V(1).Info("Built desired distribution.", "distribution", dist)
-
-	return dist, r.DistRepo.Sync(dist)
-}
-
 func (r *IngressReconciler) createDistribution(dist cloudfront.Distribution, group string) (cloudfront.Distribution, error) {
-	r.log.V(1).Info("Built desired distribution.", "distribution", dist)
 	r.log.V(1).Info("CDNStatus resource not found, creating.", "cdnStatusName", group)
 	modifiedDist, err := r.DistRepo.Create(dist)
 	if err != nil {
@@ -179,6 +255,22 @@ func (r *IngressReconciler) createDistribution(dist cloudfront.Distribution, gro
 	}
 	r.log.V(1).Info("Distribution created.", "distribution", dist)
 	return modifiedDist, err
+}
+
+func (r *IngressReconciler) syncDistribution(cdnStatus *v1alpha1.CDNStatus, builder cloudfront.DistributionBuilder) (cloudfront.Distribution, error) {
+	dist := r.build(builder.WithInfo(cdnStatus.Status.ID, cdnStatus.Status.ARN, cdnStatus.Status.Address))
+	return dist, r.DistRepo.Sync(dist)
+}
+
+func (r *IngressReconciler) deleteDistribution(cdnStatus *v1alpha1.CDNStatus, builder cloudfront.DistributionBuilder) (cloudfront.Distribution, error) {
+	dist := r.build(builder.WithInfo(cdnStatus.Status.ID, cdnStatus.Status.ARN, cdnStatus.Status.Address))
+	return dist, r.DistRepo.Delete(dist)
+}
+
+func (r *IngressReconciler) build(distBuilder cloudfront.DistributionBuilder) cloudfront.Distribution {
+	dist := distBuilder.Build()
+	r.log.V(1).Info("Built desired distribution.", "distribution", dist)
+	return dist
 }
 
 func (r *IngressReconciler) newAliases(dist cloudfront.Distribution, status *v1alpha1.CDNStatus) (toUpsert route53.Aliases, toDelete route53.Aliases) {
@@ -221,11 +313,7 @@ func (r *IngressReconciler) createCDNStatus(dist cloudfront.Distribution, group 
 }
 
 func (r *IngressReconciler) updateCDNStatus(status *v1alpha1.CDNStatus) error {
-	if err := r.Status().Update(context.Background(), status); err != nil {
-		r.log.Error(err, "Could not persist CDNStatus resource", "cdnStatus", status)
-		return err
-	}
-	return nil
+	return r.Status().Update(context.Background(), status)
 }
 
 func (r *IngressReconciler) handleFailure(err error, ingress client.Object, status *v1alpha1.CDNStatus) error {
@@ -248,6 +336,10 @@ func (r *IngressReconciler) handleSuccess(ingress client.Object, status *v1alpha
 	r.Recorder.Event(status, corev1.EventTypeNormal, reasonSuccess, msg)
 
 	return nil
+}
+
+func isRemoving(obj client.Object) bool {
+	return obj.GetDeletionTimestamp() != nil || (!hasGroupAnnotation(obj) && hasFinalizer(obj))
 }
 
 func filterIngressRef(status *v1alpha1.CDNStatus, obj client.Object) v1alpha1.CDNStatus {

--- a/controllers/ingress_reconciler.go
+++ b/controllers/ingress_reconciler.go
@@ -55,7 +55,7 @@ const (
 	reasonSuccess = "SuccessfullyReconciled"
 )
 
-var noCDNStatusForIngErr = errors.New("could not find a CDNStatus that referenced the ingress")
+var errNoCDNStatusForIng = errors.New("could not find a CDNStatus that referenced the ingress")
 
 type boundIngressesFunc func(v1alpha1.CDNStatus) ([]ingressParams, error)
 
@@ -82,7 +82,7 @@ func (r *IngressReconciler) Reconcile(reconciling ingressParams, obj client.Obje
 	}
 
 	cdnStatus, fetchStatusErr := r.fetchCDNStatus(obj)
-	if errors.Is(fetchStatusErr, noCDNStatusForIngErr) {
+	if errors.Is(fetchStatusErr, errNoCDNStatusForIng) {
 		r.log.Error(fmt.Errorf("fetching CDNStatus: %v", fetchStatusErr), "CDNStatus not found for Ingress which has no group annotation but has finalizer. Removing finalizer. State may be inconsistent.")
 		shouldHaveFinalizer := false
 		return r.reconcileFinalizer(obj, shouldHaveFinalizer)
@@ -181,7 +181,7 @@ func (r *IngressReconciler) discoverCDNStatusForIngress(ing client.Object) (*v1a
 			return &s, nil
 		}
 	}
-	return nil, fmt.Errorf("trying to match Ingress (%s/%s): %w", ing.GetNamespace(), ing.GetName(), noCDNStatusForIngErr)
+	return nil, fmt.Errorf("trying to match Ingress (%s/%s): %w", ing.GetNamespace(), ing.GetName(), errNoCDNStatusForIng)
 }
 
 func (r *IngressReconciler) handleResult(obj client.Object, cdnStatus *v1alpha1.CDNStatus, shouldHaveFinalizer bool, errs *multierror.Error) error {

--- a/controllers/predicate.go
+++ b/controllers/predicate.go
@@ -20,34 +20,42 @@
 package controllers
 
 import (
+	"reflect"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/Gympass/cdn-origin-controller/internal/strhelper"
 )
 
-type hasCdnAnnotationPredicate struct{}
+type ingressPredicate struct{}
 
-var _ predicate.Predicate = &hasCdnAnnotationPredicate{}
+var _ predicate.Predicate = &ingressPredicate{}
 
-func (p hasCdnAnnotationPredicate) Create(event event.CreateEvent) bool {
-	return hasCdnAnnotation(event.Object) && hasLoadBalancer(event.Object)
+func (p ingressPredicate) Create(event event.CreateEvent) bool {
+	return hasFinalizer(event.Object) || (hasGroupAnnotation(event.Object) && hasLoadBalancer(event.Object))
 }
 
-func (p hasCdnAnnotationPredicate) Delete(event.DeleteEvent) bool {
+func (p ingressPredicate) Delete(event event.DeleteEvent) bool {
+	return hasFinalizer(event.Object) || (hasGroupAnnotation(event.Object) && hasLoadBalancer(event.Object))
+}
+
+func (p ingressPredicate) Update(event event.UpdateEvent) bool {
+	return !reflect.DeepEqual(event.ObjectNew, event.ObjectOld) && (hasFinalizer(event.ObjectNew) || (hasGroupAnnotation(event.ObjectNew) && hasLoadBalancer(event.ObjectNew)))
+}
+
+func (p ingressPredicate) Generic(event.GenericEvent) bool {
 	return false
 }
 
-func (p hasCdnAnnotationPredicate) Update(event event.UpdateEvent) bool {
-	return hasCdnAnnotation(event.ObjectNew) && hasLoadBalancer(event.ObjectNew)
+func hasFinalizer(object client.Object) bool {
+	return strhelper.Contains(object.GetFinalizers(), cdnFinalizer)
 }
 
-func (p hasCdnAnnotationPredicate) Generic(event.GenericEvent) bool {
-	return false
-}
-
-func hasCdnAnnotation(o client.Object) bool {
+func hasGroupAnnotation(o client.Object) bool {
 	return len(o.GetAnnotations()[cdnGroupAnnotation]) > 0
 }
 

--- a/internal/cloudfront/distribution.go
+++ b/internal/cloudfront/distribution.go
@@ -132,6 +132,7 @@ func (b DistributionBuilder) WithWebACL(id string) DistributionBuilder {
 	return b
 }
 
+// WithInfo takes in identifying information from an existing CloudFront to populate the resulting Distribution
 func (b DistributionBuilder) WithInfo(id string, arn string, address string) DistributionBuilder {
 	b.id = id
 	b.arn = arn

--- a/internal/cloudfront/distribution.go
+++ b/internal/cloudfront/distribution.go
@@ -38,20 +38,6 @@ type Distribution struct {
 	WebACLID         string
 }
 
-// AddOrigin adds a custom Origin to a Distribution
-func (d *Distribution) AddOrigin(customOrigin Origin) {
-	d.CustomOrigins = append(d.CustomOrigins, customOrigin)
-}
-
-// AddAlternateDomains adds given domains to a Distribution
-func (d *Distribution) AddAlternateDomains(domains []string) {
-	for _, domain := range domains {
-		if !strhelper.Contains(d.AlternateDomains, domain) {
-			d.AlternateDomains = append(d.AlternateDomains, domain)
-		}
-	}
-}
-
 type tlsConfig struct {
 	Enabled          bool
 	CertARN          string
@@ -66,8 +52,11 @@ type loggingConfig struct {
 
 // DistributionBuilder allows the construction of a Distribution
 type DistributionBuilder struct {
+	id                  string
+	address             string
 	alternateDomains    []string
-	customOrigin        Origin
+	arn                 string
+	customOrigins       []Origin
 	defaultOriginDomain string
 	description         string
 	ipv6Enabled         bool
@@ -80,14 +69,19 @@ type DistributionBuilder struct {
 }
 
 // NewDistributionBuilder takes required arguments for a distribution and returns a DistributionBuilder
-func NewDistributionBuilder(customOrigin Origin, defaultOriginDomain, description, priceClass, group string) DistributionBuilder {
+func NewDistributionBuilder(defaultOriginDomain, description, priceClass, group string) DistributionBuilder {
 	return DistributionBuilder{
-		customOrigin:        customOrigin,
 		description:         description,
 		defaultOriginDomain: defaultOriginDomain,
 		priceClass:          priceClass,
 		group:               group,
 	}
+}
+
+// WithOrigin takes in a slice of Origin that should be part of the Distribution
+func (b DistributionBuilder) WithOrigin(o Origin) DistributionBuilder {
+	b.customOrigins = append(b.customOrigins, o)
+	return b
 }
 
 // WithLogging takes in bucket address and file prefix to enable sending CF logs to S3
@@ -122,9 +116,13 @@ func (b DistributionBuilder) WithIPv6() DistributionBuilder {
 	return b
 }
 
-// WithAlternateDomains takes a slice of domains to be configured as the Distribution's alternate domains
+// WithAlternateDomains takes a slice of domains to be added to the Distribution's alternate domains
 func (b DistributionBuilder) WithAlternateDomains(domains []string) DistributionBuilder {
-	b.alternateDomains = domains
+	for _, domain := range domains {
+		if !strhelper.Contains(b.alternateDomains, domain) {
+			b.alternateDomains = append(b.alternateDomains, domain)
+		}
+	}
 	return b
 }
 
@@ -134,10 +132,20 @@ func (b DistributionBuilder) WithWebACL(id string) DistributionBuilder {
 	return b
 }
 
+func (b DistributionBuilder) WithInfo(id string, arn string, address string) DistributionBuilder {
+	b.id = id
+	b.arn = arn
+	b.address = address
+	return b
+}
+
 // Build constructs a Distribution taking into account all configuration set by previous "With*" method calls
 func (b DistributionBuilder) Build() Distribution {
 	return Distribution{
-		CustomOrigins:    []Origin{b.customOrigin},
+		ID:               b.id,
+		ARN:              b.arn,
+		Address:          b.address,
+		CustomOrigins:    b.customOrigins,
 		DefaultOrigin:    NewOriginBuilder(b.defaultOriginDomain).Build(),
 		Description:      b.description,
 		PriceClass:       b.priceClass,

--- a/internal/cloudfront/distribution_test.go
+++ b/internal/cloudfront/distribution_test.go
@@ -41,14 +41,8 @@ func (s *OriginTestSuite) TestDistributionBuilder_New() {
 	description := "test description"
 	priceClass := "test price class"
 	group := "test group"
-	origin := cloudfront.Origin{
-		Host:            "test.custom.origin",
-		Behaviors:       nil,
-		ResponseTimeout: 30,
-	}
 
-	dist := cloudfront.NewDistributionBuilder(origin, defaultOriginDomain, description, priceClass, group).Build()
-	s.Equal([]cloudfront.Origin{origin}, dist.CustomOrigins)
+	dist := cloudfront.NewDistributionBuilder(defaultOriginDomain, description, priceClass, group).Build()
 	s.Equal("test.default.origin", dist.DefaultOrigin.Host)
 	s.Equal("test description", dist.Description)
 	s.Equal("test price class", dist.PriceClass)
@@ -56,10 +50,29 @@ func (s *OriginTestSuite) TestDistributionBuilder_New() {
 	s.Equal("test group", dist.Tags["cdn-origin-controller.gympass.com/cdn.group"])
 }
 
+func (s *OriginTestSuite) TestDistributionBuilder_WithOrigin() {
+	defaultOriginDomain := "test.default.origin"
+	description := "test description"
+	priceClass := "test price class"
+	group := "test group"
+	origin := cloudfront.Origin{
+		Host:            "test.custom.origin",
+		Behaviors:       nil,
+		ResponseTimeout: 30,
+	}
+
+	dist := cloudfront.NewDistributionBuilder(defaultOriginDomain, description, priceClass, group).
+		WithOrigin(origin).
+		Build()
+
+	s.Len(dist.CustomOrigins, 1)
+	s.Equal(origin, dist.CustomOrigins[0])
+}
+
 func (s *OriginTestSuite) TestDistributionBuilder_WithLogging() {
 	bucketAddr := "test.bucket.address"
 	prefix := "test prefix"
-	dist := cloudfront.NewDistributionBuilder(cloudfront.Origin{}, "domain", "description", "priceClass", "group").
+	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithLogging(bucketAddr, prefix).
 		Build()
 
@@ -74,7 +87,7 @@ func (s *OriginTestSuite) TestDistributionBuilder_WithCustomTags() {
 		"testKey2": "testValue2",
 	}
 
-	dist := cloudfront.NewDistributionBuilder(cloudfront.Origin{}, "domain", "description", "priceClass", "group").
+	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithTags(tags).
 		Build()
 
@@ -87,7 +100,7 @@ func (s *OriginTestSuite) TestDistributionBuilder_WithTLS() {
 	certARN := "test:arn"
 	securityPolicyID := "test-policy"
 
-	dist := cloudfront.NewDistributionBuilder(cloudfront.Origin{}, "domain", "description", "priceClass", "group").
+	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithTLS(certARN, securityPolicyID).
 		Build()
 
@@ -97,7 +110,7 @@ func (s *OriginTestSuite) TestDistributionBuilder_WithTLS() {
 }
 
 func (s *OriginTestSuite) TestDistributionBuilder_WithIPv6() {
-	dist := cloudfront.NewDistributionBuilder(cloudfront.Origin{}, "domain", "description", "priceClass", "group").
+	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithIPv6().
 		Build()
 
@@ -107,7 +120,7 @@ func (s *OriginTestSuite) TestDistributionBuilder_WithIPv6() {
 func (s *OriginTestSuite) TestDistributionBuilder_WithAlternateDomains() {
 	domains := []string{"test.domain", "test2.domain"}
 
-	dist := cloudfront.NewDistributionBuilder(cloudfront.Origin{}, "domain", "description", "priceClass", "group").
+	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithAlternateDomains(domains).
 		Build()
 
@@ -117,9 +130,21 @@ func (s *OriginTestSuite) TestDistributionBuilder_WithAlternateDomains() {
 func (s *OriginTestSuite) TestDistributionBuilder_WithWebACL() {
 	aclID := "test:acl"
 
-	dist := cloudfront.NewDistributionBuilder(cloudfront.Origin{}, "domain", "description", "priceClass", "group").
+	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithWebACL(aclID).
 		Build()
 
 	s.Equal("test:acl", dist.WebACLID)
+}
+
+func (s *OriginTestSuite) TestDistributionBuilder_WithInfo() {
+	id, arn, addr := "id", "arn", "addr"
+
+	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+		WithInfo(id, arn, addr).
+		Build()
+
+	s.Equal(id, dist.ID)
+	s.Equal(arn, dist.ARN)
+	s.Equal(addr, dist.Address)
 }

--- a/main.go
+++ b/main.go
@@ -118,10 +118,11 @@ func main() {
 	s := session.Must(session.NewSession())
 
 	callerRefFn := func() string { return time.Now().String() }
+	waitTimeout := time.Minute * 10
 	ingressReconciler := &controllers.IngressReconciler{
 		Client:    mgr.GetClient(),
 		Recorder:  mgr.GetEventRecorderFor("cdn-origin-controller"),
-		DistRepo:  cloudfront.NewDistributionRepository(awscloudfront.New(s), callerRefFn),
+		DistRepo:  cloudfront.NewDistributionRepository(awscloudfront.New(s), callerRefFn, waitTimeout),
 		AliasRepo: route53.NewRoute53AliasRepository(awsroute53.New(s), cfg),
 		Config:    cfg,
 	}


### PR DESCRIPTION
Changelog:

  - the controller is now able to deal with Ingresses being deleted or whose group annotation has been removed, implying they're no longer part of the distribution
  - when all ingresses from a group are removed the distribution is now deleted

Signed-off-by: Lucas Caparelli <lucas.caparelli@gympass.com>