### PR TITLE
[RN-318] Support user-supplied origins

### DIFF
--- a/controllers/cloudfront.go
+++ b/controllers/cloudfront.go
@@ -40,9 +40,7 @@ func newDistributionBuilder(ingresses []ingressParams, group string, cfg config.
 
 	for _, ing := range ingresses {
 		b = b.WithOrigin(newOrigin(ing))
-		if len(ing.alternateDomainNames) > 0 {
-			b = b.WithAlternateDomains(ing.alternateDomainNames)
-		}
+		b = b.WithAlternateDomains(ing.alternateDomainNames)
 	}
 
 	if cfg.CloudFrontEnableIPV6 {
@@ -75,7 +73,8 @@ func renderDescription(template, group string) string {
 func newOrigin(ing ingressParams) cloudfront.Origin {
 	builder := cloudfront.NewOriginBuilder(ing.destinationHost).
 		WithViewerFunction(ing.viewerFnARN).
-		WithResponseTimeout(ing.originRespTimeout)
+		WithResponseTimeout(ing.originRespTimeout).
+		WithRequestPolicy(ing.originReqPolicy)
 
 	patterns := pathPatterns(ing.paths)
 	for _, p := range patterns {

--- a/controllers/cloudfront.go
+++ b/controllers/cloudfront.go
@@ -73,7 +73,7 @@ func renderDescription(template, group string) string {
 }
 
 func newOrigin(ing ingressParams) cloudfront.Origin {
-	builder := cloudfront.NewOriginBuilder(ing.loadBalancer).
+	builder := cloudfront.NewOriginBuilder(ing.destinationHost).
 		WithViewerFunction(ing.viewerFnARN).
 		WithResponseTimeout(ing.originRespTimeout)
 

--- a/controllers/cloudfront_test.go
+++ b/controllers/cloudfront_test.go
@@ -38,7 +38,8 @@ type CloudFrontSuite struct {
 }
 
 func (s *CloudFrontSuite) Test_newDistributionBuilder_EmptyIngresses() {
-	dist := newDistributionBuilder(nil, "group", config.Config{}).Build()
+	dist, err := newDistributionBuilder(nil, "group", config.Config{}).Build()
+	s.NoError(err)
 	s.Len(dist.CustomOrigins, 0)
 }
 
@@ -47,13 +48,15 @@ func (s *CloudFrontSuite) Test_newDistributionBuilder_NonEmptyIngresses() {
 		{alternateDomainNames: []string{"origin1"}},
 		{alternateDomainNames: []string{"origin2", "origin3"}},
 	}
-	dist := newDistributionBuilder(ingresses, "group", config.Config{}).Build()
+	dist, err := newDistributionBuilder(ingresses, "group", config.Config{}).Build()
+	s.NoError(err)
 	s.Len(dist.CustomOrigins, 2)
 	s.Equal([]string{"origin1", "origin2", "origin3"}, dist.AlternateDomains)
 }
 
 func (s *CloudFrontSuite) Test_newDistributionBuilder_WithIPv6() {
-	dist := newDistributionBuilder(nil, "group", config.Config{CloudFrontEnableIPV6: true}).Build()
+	dist, err := newDistributionBuilder(nil, "group", config.Config{CloudFrontEnableIPV6: true}).Build()
+	s.NoError(err)
 	s.True(dist.IPv6Enabled)
 }
 
@@ -62,7 +65,8 @@ func (s *CloudFrontSuite) Test_newDistributionBuilder_WithTLS() {
 		CloudFrontCustomSSLCertARN: "arn",
 		CloudFrontSecurityPolicy:   "policy",
 	}
-	dist := newDistributionBuilder(nil, "group", cfg).Build()
+	dist, err := newDistributionBuilder(nil, "group", cfg).Build()
+	s.NoError(err)
 	s.True(dist.TLS.Enabled)
 	s.Equal("arn", dist.TLS.CertARN)
 	s.Equal("policy", dist.TLS.SecurityPolicyID)
@@ -73,7 +77,8 @@ func (s *CloudFrontSuite) Test_newDistributionBuilder_WithLogging() {
 		CloudFrontEnableLogging: true,
 		CloudFrontS3BucketLog:   "bucket",
 	}
-	dist := newDistributionBuilder(nil, "group", cfg).Build()
+	dist, err := newDistributionBuilder(nil, "group", cfg).Build()
+	s.NoError(err)
 	s.True(dist.Logging.Enabled)
 	s.Equal("group", dist.Logging.Prefix)
 	s.Equal("bucket", dist.Logging.BucketAddress)
@@ -86,13 +91,15 @@ func (s *CloudFrontSuite) Test_newDistributionBuilder_WithCustomTags() {
 			"bar": "foo",
 		},
 	}
-	dist := newDistributionBuilder(nil, "group", cfg).Build()
+	dist, err := newDistributionBuilder(nil, "group", cfg).Build()
+	s.NoError(err)
 	s.Equal("bar", dist.Tags["foo"])
 	s.Equal("foo", dist.Tags["bar"])
 }
 
 func (s *CloudFrontSuite) Test_newDistributionBuilder_WithWAF() {
-	dist := newDistributionBuilder(nil, "group", config.Config{CloudFrontWAFARN: "waf"}).Build()
+	dist, err := newDistributionBuilder(nil, "group", config.Config{CloudFrontWAFARN: "waf"}).Build()
+	s.NoError(err)
 	s.Equal("waf", dist.WebACLID)
 }
 

--- a/controllers/cloudfront_test.go
+++ b/controllers/cloudfront_test.go
@@ -45,8 +45,8 @@ func (s *CloudFrontSuite) Test_newDistributionBuilder_EmptyIngresses() {
 
 func (s *CloudFrontSuite) Test_newDistributionBuilder_NonEmptyIngresses() {
 	ingresses := []ingressParams{
-		{alternateDomainNames: []string{"origin1"}},
-		{alternateDomainNames: []string{"origin2", "origin3"}},
+		{destinationHost: "lb", alternateDomainNames: []string{"origin1"}},
+		{destinationHost: "lb", alternateDomainNames: []string{"origin2", "origin3"}},
 	}
 	dist, err := newDistributionBuilder(ingresses, "group", config.Config{}).Build()
 	s.NoError(err)
@@ -105,8 +105,7 @@ func (s *CloudFrontSuite) Test_newDistributionBuilder_WithWAF() {
 
 func (s *CloudFrontSuite) Test_newOrigin_SingleBehaviorAndRule() {
 	ip := ingressParams{
-		loadBalancer: "origin1",
-		hosts:        []string{"host1"},
+		destinationHost: "origin1",
 		paths: []path{
 			{
 				pathPattern: "/",
@@ -123,8 +122,7 @@ func (s *CloudFrontSuite) Test_newOrigin_SingleBehaviorAndRule() {
 
 func (s *CloudFrontSuite) Test_newOrigin_MultipleBehaviorsSingleRule() {
 	ip := ingressParams{
-		loadBalancer: "origin1",
-		hosts:        []string{"host1"},
+		destinationHost: "origin1",
 		paths: []path{
 			{
 				pathPattern: "/",

--- a/controllers/cloudfront_test.go
+++ b/controllers/cloudfront_test.go
@@ -143,8 +143,7 @@ func (s *CloudFrontSuite) Test_newOrigin_MultipleBehaviorsSingleRule() {
 }
 func (s *CloudFrontSuite) Test_newOrigin_MultipleBehaviorsMultipleRules() {
 	ip := ingressParams{
-		loadBalancer: "origin1",
-		hosts:        []string{"host1"},
+		destinationHost: "origin1",
 		paths: []path{
 			{
 				pathPattern: "/",
@@ -177,8 +176,7 @@ func (s *CloudFrontSuite) Test_newOrigin_MultipleBehaviorsMultipleRules() {
 // https://kubernetes.io/docs/concepts/services-networking/ingress/#examples
 func (s *CloudFrontSuite) Test_newCloudFrontOrigins_PrefixPathType_SingleSlashSpecialCase() {
 	ip := ingressParams{
-		loadBalancer: "origin1",
-		hosts:        []string{"host1"},
+		destinationHost: "origin1",
 		paths: []path{
 			{
 				pathPattern: "/",
@@ -196,8 +194,7 @@ func (s *CloudFrontSuite) Test_newCloudFrontOrigins_PrefixPathType_SingleSlashSp
 // https://kubernetes.io/docs/concepts/services-networking/ingress/#examples
 func (s *CloudFrontSuite) Test_newCloudFrontOrigins_PrefixPathType_EndsWithSlash() {
 	ip := ingressParams{
-		loadBalancer: "origin1",
-		hosts:        []string{"host1"},
+		destinationHost: "origin1",
 		paths: []path{
 			{
 				pathPattern: "/foo/",
@@ -216,8 +213,7 @@ func (s *CloudFrontSuite) Test_newCloudFrontOrigins_PrefixPathType_EndsWithSlash
 // https://kubernetes.io/docs/concepts/services-networking/ingress/#examples
 func (s *CloudFrontSuite) Test_newCloudFrontOrigins_PrefixPathType_DoesNotEndWithSlash() {
 	ip := ingressParams{
-		loadBalancer: "origin1",
-		hosts:        []string{"host1"},
+		destinationHost: "origin1",
 		paths: []path{
 			{
 				pathPattern: "/foo",

--- a/controllers/ingress_params.go
+++ b/controllers/ingress_params.go
@@ -40,6 +40,7 @@ type ingressParams struct {
 	group                string
 	paths                []path
 	viewerFnARN          string
+	originReqPolicy      string
 	originRespTimeout    int64
 	alternateDomainNames []string
 }
@@ -50,6 +51,7 @@ func newIngressParamsV1beta1(ing *networkingv1beta1.Ingress) ingressParams {
 		group:                groupAnnotationValue(ing),
 		paths:                pathsV1beta1(ing.Spec.Rules),
 		viewerFnARN:          viewerFnARN(ing),
+		originReqPolicy:      originReqPolicy(ing),
 		originRespTimeout:    originRespTimeout(ing),
 		alternateDomainNames: alternateDomainNames(ing),
 	}
@@ -75,6 +77,7 @@ func newIngressParamsV1(ing *networkingv1.Ingress) ingressParams {
 		group:                groupAnnotationValue(ing),
 		paths:                pathsV1(ing.Spec.Rules),
 		viewerFnARN:          viewerFnARN(ing),
+		originReqPolicy:      originReqPolicy(ing),
 		originRespTimeout:    originRespTimeout(ing),
 		alternateDomainNames: alternateDomainNames(ing),
 	}
@@ -102,6 +105,10 @@ func originRespTimeout(obj client.Object) int64 {
 	val := obj.GetAnnotations()[cfOrigRespTimeoutAnnotation]
 	respTimeout, _ := strconv.ParseInt(val, 10, 64)
 	return respTimeout
+}
+
+func originReqPolicy(obj client.Object) string {
+	return obj.GetAnnotations()[cfOrigReqPolicyAnnotation]
 }
 
 func groupAnnotationValue(obj client.Object) string {

--- a/controllers/ingress_v1_controller.go
+++ b/controllers/ingress_v1_controller.go
@@ -76,7 +76,7 @@ func (r *V1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 
 // BoundIngresses returns a slice of ingressParams for each Ingress associated with a particular CDNStatus
 func (r *V1Reconciler) BoundIngresses(status v1alpha1.CDNStatus) ([]ingressParams, error) {
-	var paramList []ingressParams
+	var paramsList []ingressParams
 	for _, key := range status.GetIngressKeys() {
 		ing := &networkingv1.Ingress{}
 		err := r.Client.Get(context.Background(), key, ing)
@@ -86,9 +86,17 @@ func (r *V1Reconciler) BoundIngresses(status v1alpha1.CDNStatus) ([]ingressParam
 			return nil, fmt.Errorf("fetching ingress %s: %v", key.String(), err)
 		}
 		r.log.V(1).Info("Fetched bound Ingress", "name", ing.Name, "namespace", ing.Namespace)
-		paramList = append(paramList, newIngressParamsV1(ing))
+
+		params := newIngressParamsV1(ing)
+		paramsList = append(paramsList, params)
+
+		userOriginParamsList, err := r.IngressReconciler.ingressParamsForUserOrigins(params.group, ing)
+		if err != nil {
+			return nil, fmt.Errorf("creating user origins desired state: %v", err)
+		}
+		paramsList = append(paramsList, userOriginParamsList...)
 	}
-	return paramList, nil
+	return paramsList, nil
 }
 
 // SetupWithManager ...

--- a/controllers/user_origin.go
+++ b/controllers/user_origin.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package controllers
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+type userOrigin struct {
+	Host              string   `yaml:"host"`
+	ResponseTimeout   int64    `yaml:"responseTimeout"`
+	Paths             []string `yaml:"paths"`
+	ViewerFunctionARN string   `yaml:"viewerFunctionARN"`
+	RequestPolicy     string   `yaml:"originRequestPolicy"`
+}
+
+func (o userOrigin) paths() []path {
+	var paths []path
+	for _, p := range o.Paths {
+		paths = append(paths, path{pathPattern: p})
+	}
+	return paths
+}
+
+func (o userOrigin) isValid() bool {
+	return len(o.Host) > 0 && len(o.Paths) > 0
+}
+
+func userOriginsFromYAML(originsData []byte) ([]userOrigin, error) {
+	origins := []userOrigin{}
+	err := yaml.Unmarshal(originsData, &origins)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, o := range origins {
+		if !o.isValid() {
+			return nil, fmt.Errorf("user origin invalid. Must have at lease one path and must have a host: has %d paths and the host is %q", len(o.Paths), o.Host)
+		}
+	}
+
+	return origins, nil
+}

--- a/controllers/user_origin_test.go
+++ b/controllers/user_origin_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestRunUserOriginTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &userOriginSuite{})
+}
+
+type userOriginSuite struct {
+	suite.Suite
+}
+
+func (s *userOriginSuite) Test_userOriginsFromYAML_Success() {
+	testCases := []struct {
+		name     string
+		data     string
+		expected []userOrigin
+	}{
+		{
+			name: "Has a single user origin",
+			data: `
+                  - host: foo.com
+                    responseTimeout: 35
+                    paths:
+                      - /foo
+                      - /foo/*
+                    viewerFunctionARN: foo
+                    originRequestPolicy: None`,
+			expected: []userOrigin{
+				{
+					Host:              "foo.com",
+					ResponseTimeout:   35,
+					Paths:             []string{"/foo", "/foo/*"},
+					ViewerFunctionARN: "foo",
+					RequestPolicy:     "None",
+				},
+			},
+		},
+		{
+			name: "Has multiple user origins",
+			data: `
+                - host: foo.com
+                  paths:
+                    - /foo
+                  viewerFunctionARN: foo
+                  originRequestPolicy: None
+                - host: bar.com
+                  responseTimeout: 35
+                  paths:
+                    - /bar`,
+			expected: []userOrigin{
+				{
+					Host:              "foo.com",
+					Paths:             []string{"/foo"},
+					ViewerFunctionARN: "foo",
+					RequestPolicy:     "None",
+				},
+				{
+					Host:            "bar.com",
+					ResponseTimeout: 35,
+					Paths:           []string{"/bar"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := userOriginsFromYAML([]byte(tc.data))
+		s.NoError(err, "test: %s", tc.name)
+		s.Equal(tc.expected, got, "test: %s", tc.name)
+	}
+}
+
+func (s *userOriginSuite) Test_userOriginsFromYAML_InvalidYAMLData() {
+	_, err := userOriginsFromYAML([]byte("*"))
+	s.Error(err)
+}
+
+func (s *userOriginSuite) Test_userOriginsFromYAML_InvalidUserOrigin() {
+	testCases := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "No host",
+			data: `
+                  - responseTimeout: 35
+                    paths:
+                      - /foo
+                      - /foo/*
+                    viewerFunctionARN: foo
+                    originRequestPolicy: None`,
+		},
+		{
+			name: "No paths",
+			data: `
+                - host: foo.com
+                  viewerFunctionARN: foo
+                  originRequestPolicy: None`,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := userOriginsFromYAML([]byte(tc.data))
+		s.Error(err, "test: %s", tc.name)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.17.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2

--- a/internal/cloudfront/distribution.go
+++ b/internal/cloudfront/distribution.go
@@ -82,7 +82,7 @@ func NewDistributionBuilder(defaultOriginDomain, description, priceClass, group 
 	}
 }
 
-// WithOrigin takes in a slice of Origin that should be part of the Distribution
+// WithOrigin takes in an Origin that should be part of the Distribution
 func (b DistributionBuilder) WithOrigin(o Origin) DistributionBuilder {
 	b.customOrigins = append(b.customOrigins, o)
 	return b

--- a/internal/cloudfront/distribution.go
+++ b/internal/cloudfront/distribution.go
@@ -19,7 +19,11 @@
 
 package cloudfront
 
-import "github.com/Gympass/cdn-origin-controller/internal/strhelper"
+import (
+	"fmt"
+
+	"github.com/Gympass/cdn-origin-controller/internal/strhelper"
+)
 
 // Distribution represents a CloudFront distribution
 type Distribution struct {
@@ -141,8 +145,8 @@ func (b DistributionBuilder) WithInfo(id string, arn string, address string) Dis
 }
 
 // Build constructs a Distribution taking into account all configuration set by previous "With*" method calls
-func (b DistributionBuilder) Build() Distribution {
-	return Distribution{
+func (b DistributionBuilder) Build() (Distribution, error) {
+	d := Distribution{
 		ID:               b.id,
 		ARN:              b.arn,
 		Address:          b.address,
@@ -157,6 +161,11 @@ func (b DistributionBuilder) Build() Distribution {
 		AlternateDomains: b.alternateDomains,
 		WebACLID:         b.webACLID,
 	}
+
+	if err := validate(d); err != nil {
+		return Distribution{}, err
+	}
+	return d, nil
 }
 
 func (b DistributionBuilder) generateTags() map[string]string {
@@ -178,4 +187,21 @@ func (b DistributionBuilder) defaultTags() map[string]string {
 	tags[managedByTagKey] = managedByTagValue
 	tags[groupTagKey] = b.group
 	return tags
+}
+
+func validate(d Distribution) error {
+	var origins []Origin
+	origins = append(origins, d.DefaultOrigin)
+	origins = append(origins, d.CustomOrigins...)
+
+	existingOrigins := make(map[string]Origin)
+	for _, o := range origins {
+		if existing, ok := existingOrigins[o.Host]; ok {
+			if !existing.HasEqualParameters(o) {
+				return fmt.Errorf("same host (%s) specified twice with different parameters for origin configuration", o.Host)
+			}
+		}
+		existingOrigins[o.Host] = o
+	}
+	return nil
 }

--- a/internal/cloudfront/distribution_test.go
+++ b/internal/cloudfront/distribution_test.go
@@ -63,7 +63,7 @@ func (s *DistributionTestSuite) TestDistributionBuilder_WithOrigin() {
 	}
 
 	dist, err := cloudfront.NewDistributionBuilder(defaultOriginDomain, description, priceClass, group).
-		WithOrigins(origin).
+		WithOrigin(origin).
 		Build()
 
 	s.NoError(err)
@@ -163,7 +163,8 @@ func (s *DistributionTestSuite) TestDistributionBuilder_InvalidDistribution() {
 	origin2 := cloudfront.NewOriginBuilder("host").WithResponseTimeout(40).Build()
 
 	_, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
-		WithOrigins(origin1, origin2).
+		WithOrigin(origin1).
+		WithOrigin(origin2).
 		Build()
 
 	s.Error(err)

--- a/internal/cloudfront/distribution_test.go
+++ b/internal/cloudfront/distribution_test.go
@@ -36,13 +36,14 @@ type DistributionTestSuite struct {
 	suite.Suite
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_New() {
+func (s *DistributionTestSuite) TestDistributionBuilder_New() {
 	defaultOriginDomain := "test.default.origin"
 	description := "test description"
 	priceClass := "test price class"
 	group := "test group"
 
-	dist := cloudfront.NewDistributionBuilder(defaultOriginDomain, description, priceClass, group).Build()
+	dist, err := cloudfront.NewDistributionBuilder(defaultOriginDomain, description, priceClass, group).Build()
+	s.NoError(err)
 	s.Equal("test.default.origin", dist.DefaultOrigin.Host)
 	s.Equal("test description", dist.Description)
 	s.Equal("test price class", dist.PriceClass)
@@ -50,7 +51,7 @@ func (s *OriginTestSuite) TestDistributionBuilder_New() {
 	s.Equal("test group", dist.Tags["cdn-origin-controller.gympass.com/cdn.group"])
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithOrigin() {
+func (s *DistributionTestSuite) TestDistributionBuilder_WithOrigin() {
 	defaultOriginDomain := "test.default.origin"
 	description := "test description"
 	priceClass := "test price class"
@@ -61,90 +62,109 @@ func (s *OriginTestSuite) TestDistributionBuilder_WithOrigin() {
 		ResponseTimeout: 30,
 	}
 
-	dist := cloudfront.NewDistributionBuilder(defaultOriginDomain, description, priceClass, group).
-		WithOrigin(origin).
+	dist, err := cloudfront.NewDistributionBuilder(defaultOriginDomain, description, priceClass, group).
+		WithOrigins(origin).
 		Build()
 
+	s.NoError(err)
 	s.Len(dist.CustomOrigins, 1)
 	s.Equal(origin, dist.CustomOrigins[0])
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithLogging() {
+func (s *DistributionTestSuite) TestDistributionBuilder_WithLogging() {
 	bucketAddr := "test.bucket.address"
 	prefix := "test prefix"
-	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithLogging(bucketAddr, prefix).
 		Build()
 
+	s.NoError(err)
 	s.True(dist.Logging.Enabled)
 	s.Equal("test.bucket.address", dist.Logging.BucketAddress)
 	s.Equal("test prefix", dist.Logging.Prefix)
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithCustomTags() {
+func (s *DistributionTestSuite) TestDistributionBuilder_WithCustomTags() {
 	tags := map[string]string{
 		"testKey":  "testValue",
 		"testKey2": "testValue2",
 	}
 
-	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithTags(tags).
 		Build()
 
+	s.NoError(err)
 	for k, v := range tags {
 		s.Equal(v, dist.Tags[k], "key: %s\tvalue: %s", k, v)
 	}
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithTLS() {
+func (s *DistributionTestSuite) TestDistributionBuilder_WithTLS() {
 	certARN := "test:arn"
 	securityPolicyID := "test-policy"
 
-	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithTLS(certARN, securityPolicyID).
 		Build()
 
+	s.NoError(err)
 	s.True(dist.TLS.Enabled)
 	s.Equal("test:arn", dist.TLS.CertARN)
 	s.Equal("test-policy", dist.TLS.SecurityPolicyID)
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithIPv6() {
-	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+func (s *DistributionTestSuite) TestDistributionBuilder_WithIPv6() {
+	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithIPv6().
 		Build()
 
+	s.NoError(err)
 	s.True(dist.IPv6Enabled)
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithAlternateDomains() {
+func (s *DistributionTestSuite) TestDistributionBuilder_WithAlternateDomains() {
 	domains := []string{"test.domain", "test2.domain"}
 
-	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithAlternateDomains(domains).
 		Build()
 
+	s.NoError(err)
 	s.Equal(domains, dist.AlternateDomains)
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithWebACL() {
+func (s *DistributionTestSuite) TestDistributionBuilder_WithWebACL() {
 	aclID := "test:acl"
 
-	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithWebACL(aclID).
 		Build()
 
+	s.NoError(err)
 	s.Equal("test:acl", dist.WebACLID)
 }
 
-func (s *OriginTestSuite) TestDistributionBuilder_WithInfo() {
+func (s *DistributionTestSuite) TestDistributionBuilder_WithInfo() {
 	id, arn, addr := "id", "arn", "addr"
 
-	dist := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
 		WithInfo(id, arn, addr).
 		Build()
 
+	s.NoError(err)
 	s.Equal(id, dist.ID)
 	s.Equal(arn, dist.ARN)
 	s.Equal(addr, dist.Address)
+}
+
+func (s *DistributionTestSuite) TestDistributionBuilder_InvalidDistribution() {
+	origin1 := cloudfront.NewOriginBuilder("host").WithResponseTimeout(35).Build()
+	origin2 := cloudfront.NewOriginBuilder("host").WithResponseTimeout(40).Build()
+
+	_, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group").
+		WithOrigins(origin1, origin2).
+		Build()
+
+	s.Error(err)
 }

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -33,6 +33,7 @@ type Origin struct {
 	ResponseTimeout int64
 }
 
+// HasEqualParameters returns whether both Origins have the same parameters. It ignores differences in Behaviors
 func (o Origin) HasEqualParameters(o2 Origin) bool {
 	return o.Host == o2.Host && o.ResponseTimeout == o2.ResponseTimeout
 }

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -29,28 +29,35 @@ type Origin struct {
 	Host string
 	// Behaviors is the collection of Behaviors associated with this Origin
 	Behaviors []Behavior
-	// ResponseTimeout
+	// ResponseTimeout is how long CloudFront will wait for a response from the Origin in seconds
 	ResponseTimeout int64
+}
+
+func (o Origin) HasEqualParameters(o2 Origin) bool {
+	return o.Host == o2.Host && o.ResponseTimeout == o2.ResponseTimeout
 }
 
 // Behavior represents a CloudFront Cache Behavior
 type Behavior struct {
 	// PathPattern is the path pattern used when configuring the Behavior
 	PathPattern string
+	// RequestPolicy is the ID of the origin request policy to be associated with this Behavior
+	RequestPolicy string
 	// ViewerFnARN is the ARN of the function to be associated with the Behavior's viewer requests
 	ViewerFnARN string
 }
 
 // OriginBuilder allows the construction of a Origin
 type OriginBuilder struct {
-	origin      Origin
-	viewerFnARN string
-	respTimeout int64
+	origin        Origin
+	viewerFnARN   string
+	requestPolicy string
+	respTimeout   int64
 }
 
 // NewOriginBuilder returns an OriginBuilder for a given host
 func NewOriginBuilder(host string) OriginBuilder {
-	return OriginBuilder{origin: Origin{Host: host, ResponseTimeout: defaultResponseTimeout}}
+	return OriginBuilder{origin: Origin{Host: host, ResponseTimeout: defaultResponseTimeout}, requestPolicy: allViewerOriginRequestPolicyID}
 }
 
 // WithBehavior adds a Behavior to the Origin being built given a path pattern the Behavior should respond for
@@ -62,6 +69,14 @@ func (b OriginBuilder) WithBehavior(pathPattern string) OriginBuilder {
 // WithViewerFunction associates a function with all viewer requests of all Behaviors in the Origin being built
 func (b OriginBuilder) WithViewerFunction(fnARN string) OriginBuilder {
 	b.viewerFnARN = fnARN
+	return b
+}
+
+// WithRequestPolicy associates a given origin request policy ID with all Behaviors in the Origin being built
+func (b OriginBuilder) WithRequestPolicy(policy string) OriginBuilder {
+	if len(policy) > 0 {
+		b.requestPolicy = policy
+	}
 	return b
 }
 
@@ -77,6 +92,8 @@ func (b OriginBuilder) Build() Origin {
 		b.addViewerFnToBehaviors()
 	}
 
+	b.addRequestPolicyToBehaviors()
+
 	if b.respTimeout > 0 {
 		b.origin.ResponseTimeout = b.respTimeout
 	}
@@ -86,5 +103,11 @@ func (b OriginBuilder) Build() Origin {
 func (b OriginBuilder) addViewerFnToBehaviors() {
 	for i := range b.origin.Behaviors {
 		b.origin.Behaviors[i].ViewerFnARN = b.viewerFnARN
+	}
+}
+
+func (b OriginBuilder) addRequestPolicyToBehaviors() {
+	for i := range b.origin.Behaviors {
+		b.origin.Behaviors[i].RequestPolicy = b.requestPolicy
 	}
 }


### PR DESCRIPTION
Changelog:
  - added `cdn-origin-controller.gympass.com/cf.origin-request-policy` annotation for controlling origin request policies in cache behaviors
  - added `cdn-origin-controller.gympass.com/cf.user-origins` annotation for controlling user-supplied origin/behavior definitions to support more complex use-cases that require more granular control
  - fixed a bug where two different origins with same host and different configuration (e.g., timeout) were accepted. One of these would eventually be chosen over the other when de-duplicating Origins, leading to one of them being held as "true" while others were ignored.
    
    The controller now returns a reconciliation error if two or more origins with the same hostname are specified with different parameters.
