### PR TITLE
[RN-329] Use CDNClass to avoid resource name collision

### DIFF
--- a/charts/cdn-origin-controller/Chart.yaml
+++ b/charts/cdn-origin-controller/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.0.8"
 description: The cdn-origin-controller Helm Chart
 name: cdn-origin-controller
-version: v0.0.6
+version: v0.0.7

--- a/charts/cdn-origin-controller/templates/deployment.yaml
+++ b/charts/cdn-origin-controller/templates/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cdn-origin-controller.name" . }}
+  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
   labels:
 {{ include "cdn-origin-controller.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}
+      app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         {{- toYaml .Values.deployment.annotations | nindent 8 }}
       labels:
-        app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}
+        app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/charts/cdn-origin-controller/templates/role.yaml
+++ b/charts/cdn-origin-controller/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: {{ include "cdn-origin-controller.name" . }}
+  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
 rules:
 - apiGroups:
   - ""

--- a/charts/cdn-origin-controller/templates/role_binding.yaml
+++ b/charts/cdn-origin-controller/templates/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "cdn-origin-controller.name" . }}
+  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "cdn-origin-controller.name" . }}
+  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "cdn-origin-controller.serviceAccountName" . }}

--- a/charts/cdn-origin-controller/templates/service.yaml
+++ b/charts/cdn-origin-controller/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cdn-origin-controller.name" . }}
+  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
   labels:
 {{ include "cdn-origin-controller.labels" . | indent 4 }}
 spec:
@@ -12,5 +12,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}
+    app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/cdn-origin-controller/values.yaml
+++ b/charts/cdn-origin-controller/values.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 
+cdnClass: default
+
 image:
   repository: ghcr.io/gympass/cdn-origin-controller
   tag: v0.0.8


### PR DESCRIPTION
Preventing instances of different classes being deployed with same name for resources in Kubernetes.