### PR TITLE
[RN-329] Add permissions to handle CDNStatus

### DIFF
--- a/charts/cdn-origin-controller/Chart.yaml
+++ b/charts/cdn-origin-controller/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.0.8"
 description: The cdn-origin-controller Helm Chart
 name: cdn-origin-controller
-version: v0.0.7
+version: v0.0.8

--- a/charts/cdn-origin-controller/templates/role.yaml
+++ b/charts/cdn-origin-controller/templates/role.yaml
@@ -12,6 +12,26 @@ rules:
   - create
   - patch
 - apiGroups:
+  - cdn.gympass.com
+  resources:
+  - cdnstatuses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cdn.gympass.com
+  resources:
+  - cdnstatuses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,26 @@ rules:
   - create
   - patch
 - apiGroups:
+  - cdn.gympass.com
+  resources:
+  - cdnstatuses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cdn.gympass.com
+  resources:
+  - cdnstatuses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses

--- a/controllers/ingress_v1_controller.go
+++ b/controllers/ingress_v1_controller.go
@@ -48,6 +48,8 @@ type V1Reconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/finalizers,verbs=update
+// +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses/status,verbs=get;update;patch
 
 //Reconcile a v1 Ingress resource
 func (r *V1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/ingress_v1beta1_controller.go
+++ b/controllers/ingress_v1beta1_controller.go
@@ -48,6 +48,8 @@ type V1beta1Reconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/finalizers,verbs=update
+// +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses/status,verbs=get;update;patch
 
 //Reconcile a v1beta1 Ingress resource
 func (r *V1beta1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Preventing errors such as:
```
E1214 13:46:22.922388       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.CDNStatus: failed to list *v1alpha1.CDNStatus: cdnstatuses.cdn.gympass.com is forbidden: User "system:serviceaccount:platform:cdn-origin-controller" cannot list resource "cdnstatuses" in API group "cdn.gympass.com" at the cluster scope
```
Signed-off-by: Lucas Caparelli <lucas.caparelli@gympass.com>