### PR TITLE
Grant update permission on Ingresses

### DIFF
--- a/api/v1alpha1/cdnstatus_types.go
+++ b/api/v1alpha1/cdnstatus_types.go
@@ -43,6 +43,8 @@ type CDNStatusStatus struct {
 	Ingresses IngressRefs `json:"ingresses,omitempty"`
 	Aliases   []string    `json:"aliases,omitempty"`
 	Address   string      `json:"address,omitempty"`
+	// +optional
+	// +nullable
 	DNS       *DNSStatus  `json:"dns,omitempty"`
 }
 

--- a/api/v1alpha1/cdnstatus_types.go
+++ b/api/v1alpha1/cdnstatus_types.go
@@ -45,7 +45,7 @@ type CDNStatusStatus struct {
 	Address   string      `json:"address,omitempty"`
 	// +optional
 	// +nullable
-	DNS       *DNSStatus  `json:"dns,omitempty"`
+	DNS *DNSStatus `json:"dns,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/charts/cdn-origin-controller/Chart.yaml
+++ b/charts/cdn-origin-controller/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.0.8"
 description: The cdn-origin-controller Helm Chart
 name: cdn-origin-controller
-version: v0.0.8
+version: v0.0.9

--- a/charts/cdn-origin-controller/templates/role.yaml
+++ b/charts/cdn-origin-controller/templates/role.yaml
@@ -39,6 +39,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/config/crd/bases/cdn.gympass.com_cdnstatuses.yaml
+++ b/config/crd/bases/cdn.gympass.com_cdnstatuses.yaml
@@ -57,6 +57,7 @@ spec:
               dns:
                 description: DNSStatus provides status regarding the creation of DNS
                   records for aliases
+                nullable: true
                 properties:
                   records:
                     items:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - networking.k8s.io

--- a/controllers/ingress_v1_controller.go
+++ b/controllers/ingress_v1_controller.go
@@ -46,7 +46,7 @@ type V1Reconciler struct {
 }
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/finalizers,verbs=update
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses/status,verbs=get;update;patch

--- a/controllers/ingress_v1beta1_controller.go
+++ b/controllers/ingress_v1beta1_controller.go
@@ -46,7 +46,7 @@ type V1beta1Reconciler struct {
 }
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/finalizers,verbs=update
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses/status,verbs=get;update;patch


### PR DESCRIPTION
Preventing errors when managing the finalizer.

Additionally fixed a bug where a CDNStatus with no DNS records was invalid.