### PR TITLE
[RN-3322] Don't use TXT prefix and check all TXT values for record ownership

### DIFF
--- a/api/v1alpha1/cdnstatus_types.go
+++ b/api/v1alpha1/cdnstatus_types.go
@@ -85,7 +85,7 @@ func (c *CDNStatus) UpsertDNSRecords(records []string) {
 	}
 
 	if c.Status.DNS == nil {
-		c.Status.DNS = &DNSStatus{Records: records}
+		c.Status.DNS = &DNSStatus{Records: records, Synced: true}
 		return
 	}
 
@@ -103,6 +103,9 @@ func (c *CDNStatus) RemoveDNSRecords(records []string) {
 			return i != it
 		}
 		c.Status.DNS.Records = strhelper.Filter(c.Status.DNS.Records, predicate)
+	}
+	if len(c.Status.DNS.Records) == 0 {
+		c.Status.DNS = nil
 	}
 }
 
@@ -148,6 +151,13 @@ func (c *CDNStatus) GetIngressKeys() []client.ObjectKey {
 		keys = append(keys, ing.ToNamespacedName())
 	}
 	return keys
+}
+
+// SetDNSSync sets the DNS sync status if there is any DNS status to report
+func (c *CDNStatus) SetDNSSync(synced bool) {
+	if c.Status.DNS != nil {
+		c.Status.DNS.Synced = synced
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/ingress_reconciler.go
+++ b/controllers/ingress_reconciler.go
@@ -327,7 +327,9 @@ func (r *IngressReconciler) build(distBuilder cloudfront.DistributionBuilder) (c
 func (r *IngressReconciler) newAliases(dist cloudfront.Distribution, status *v1alpha1.CDNStatus) (toUpsert route53.Aliases, toDelete route53.Aliases) {
 	var deleting []string
 	if status.Status.DNS != nil {
-		deleting = getDeletions(dist.AlternateDomains, status.Status.DNS.Records)
+		desiredDomains := route53.NormalizeDomains(dist.AlternateDomains)
+		existingDomains := status.Status.DNS.Records
+		deleting = getDeletions(desiredDomains, existingDomains)
 	}
 
 	return route53.NewAliases(dist.Address, dist.AlternateDomains, dist.IPv6Enabled), route53.NewAliases(dist.Address, deleting, dist.IPv6Enabled)

--- a/internal/route53/alias.go
+++ b/internal/route53/alias.go
@@ -59,12 +59,8 @@ func NewAliases(target string, domains []string, ipv6Enabled bool) Aliases {
 	}
 
 	for _, domain := range domains {
-		if !strings.HasSuffix(domain, ".") {
-			domain += "."
-		}
-
 		entry := Entry{
-			Name: domain,
+			Name: normalizeDomain(domain),
 			Type: types,
 		}
 
@@ -72,4 +68,20 @@ func NewAliases(target string, domains []string, ipv6Enabled bool) Aliases {
 	}
 
 	return aliases
+}
+
+// NormalizeDomains adds a "." at the end of each domain in the domains slice if not present already.
+func NormalizeDomains(domains []string) []string {
+	var result []string
+	for _, d := range domains {
+		result = append(result, normalizeDomain(d))
+	}
+	return result
+}
+
+func normalizeDomain(domain string) string {
+	if !strings.HasSuffix(domain, ".") {
+		return domain + "."
+	}
+	return domain
 }


### PR DESCRIPTION
Since prefixes didn't work very well for alternate domains that were
also the root of their DNS zone. For example, "foo.com" from the
"foo.com" zone would end up with a TXT record "prefix-foo.com", which
is not valid for the "foo.com" zone, but is valid for the "com" zone.

Now we iterate over each value of a TXT record to determine ownership.
It's ok if there are TXT name collisions.

Signed-off-by: Lucas Caparelli <lucas.caparelli@gympass.com>