### PR TITLE
[RN-341] Handle duplicate paths in the same Origin

### DIFF
--- a/api/v1alpha1/cdnstatus_types.go
+++ b/api/v1alpha1/cdnstatus_types.go
@@ -98,6 +98,10 @@ func (c *CDNStatus) UpsertDNSRecords(records []string) {
 
 // RemoveDNSRecords deletes the given records from the DNS status section
 func (c *CDNStatus) RemoveDNSRecords(records []string) {
+	if c.Status.DNS == nil {
+		return
+	}
+
 	for _, it := range records {
 		predicate := func(i string) bool {
 			return i != it

--- a/controllers/cloudfront_test.go
+++ b/controllers/cloudfront_test.go
@@ -138,8 +138,17 @@ func (s *CloudFrontSuite) Test_newOrigin_MultipleBehaviorsSingleRule() {
 	origin := newOrigin(ip)
 	s.Equal("origin1", origin.Host)
 	s.Len(origin.Behaviors, 2)
-	s.Equal("/", origin.Behaviors[0].PathPattern)
-	s.Equal("/foo", origin.Behaviors[1].PathPattern)
+
+	gotPaths := []string{
+		origin.Behaviors[0].PathPattern,
+		origin.Behaviors[1].PathPattern,
+	}
+	expectedPaths := []string{
+		"/",
+		"/foo",
+	}
+
+	s.ElementsMatch(expectedPaths, gotPaths)
 }
 func (s *CloudFrontSuite) Test_newOrigin_MultipleBehaviorsMultipleRules() {
 	ip := ingressParams{
@@ -167,10 +176,21 @@ func (s *CloudFrontSuite) Test_newOrigin_MultipleBehaviorsMultipleRules() {
 	origin := newOrigin(ip)
 	s.Equal("origin1", origin.Host)
 	s.Len(origin.Behaviors, 4)
-	s.Equal("/", origin.Behaviors[0].PathPattern)
-	s.Equal("/foo", origin.Behaviors[1].PathPattern)
-	s.Equal("/foo/bar", origin.Behaviors[2].PathPattern)
-	s.Equal("/bar", origin.Behaviors[3].PathPattern)
+
+	gotPaths := []string{
+		origin.Behaviors[0].PathPattern,
+		origin.Behaviors[1].PathPattern,
+		origin.Behaviors[2].PathPattern,
+		origin.Behaviors[3].PathPattern,
+	}
+	expectedPaths := []string{
+		"/",
+		"/foo",
+		"/foo/bar",
+		"/bar",
+	}
+
+	s.ElementsMatch(expectedPaths, gotPaths)
 }
 
 // https://kubernetes.io/docs/concepts/services-networking/ingress/#examples
@@ -206,8 +226,17 @@ func (s *CloudFrontSuite) Test_newCloudFrontOrigins_PrefixPathType_EndsWithSlash
 	origin := newOrigin(ip)
 	s.Equal("origin1", origin.Host)
 	s.Len(origin.Behaviors, 2)
-	s.Equal("/foo", origin.Behaviors[0].PathPattern)
-	s.Equal("/foo/*", origin.Behaviors[1].PathPattern)
+
+	gotPaths := []string{
+		origin.Behaviors[0].PathPattern,
+		origin.Behaviors[1].PathPattern,
+	}
+	expectedPaths := []string{
+		"/foo",
+		"/foo/*",
+	}
+
+	s.ElementsMatch(expectedPaths, gotPaths)
 }
 
 // https://kubernetes.io/docs/concepts/services-networking/ingress/#examples
@@ -225,6 +254,15 @@ func (s *CloudFrontSuite) Test_newCloudFrontOrigins_PrefixPathType_DoesNotEndWit
 	origin := newOrigin(ip)
 	s.Equal("origin1", origin.Host)
 	s.Len(origin.Behaviors, 2)
-	s.Equal("/foo", origin.Behaviors[0].PathPattern)
-	s.Equal("/foo/*", origin.Behaviors[1].PathPattern)
+
+	gotPaths := []string{
+		origin.Behaviors[0].PathPattern,
+		origin.Behaviors[1].PathPattern,
+	}
+	expectedPaths := []string{
+		"/foo",
+		"/foo/*",
+	}
+
+	s.ElementsMatch(expectedPaths, gotPaths)
 }

--- a/controllers/ingress_reconciler.go
+++ b/controllers/ingress_reconciler.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -222,11 +223,11 @@ func (r *IngressReconciler) discoverCDNStatusForIngress(ing client.Object) (*v1a
 }
 
 func (r *IngressReconciler) handleResult(obj client.Object, cdnStatus *v1alpha1.CDNStatus, shouldHaveFinalizer bool, errs *multierror.Error) error {
-	err := r.reconcileStatus(cdnStatus)
-	if err != nil {
+	if err := r.reconcileStatus(cdnStatus); err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("reconciling CDNStatus: %v", err))
 	}
-	err = r.reconcileFinalizer(obj, shouldHaveFinalizer)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, r.retryableReconcileFinalizer(obj, shouldHaveFinalizer))
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("reconciling finalizer: %v", err))
 	}
@@ -239,24 +240,45 @@ func (r *IngressReconciler) handleResult(obj client.Object, cdnStatus *v1alpha1.
 
 func (r *IngressReconciler) reconcileStatus(cdnStatus *v1alpha1.CDNStatus) error {
 	if len(cdnStatus.Status.Ingresses) == 0 {
-		if err := r.Delete(context.Background(), cdnStatus); err != nil {
-			r.log.Error(err, "Could not delete CDNStatus resource", "cdnStatus", cdnStatus)
-			return err
-		}
+		return r.deleteCDNStatus(cdnStatus)
 	}
-	if err := r.updateCDNStatus(cdnStatus); err != nil {
-		r.log.Error(err, "Could not persist CDNStatus resource", "cdnStatus", cdnStatus)
+	return r.updateCDNStatus(cdnStatus)
+}
+
+func (r *IngressReconciler) deleteCDNStatus(cdnStatus *v1alpha1.CDNStatus) error {
+	if err := r.Delete(context.Background(), cdnStatus); err != nil {
+		r.log.Error(err, "Could not delete CDNStatus resource", "cdnStatus", cdnStatus)
 		return err
 	}
 	return nil
 }
 
+func (r *IngressReconciler) updateCDNStatus(status *v1alpha1.CDNStatus) error {
+	if err := r.Status().Update(context.Background(), status); err != nil {
+		r.log.Error(err, "Could not persist CDNStatus resource", "cdnStatus", status)
+		return err
+	}
+	return nil
+}
+
+func (r *IngressReconciler) retryableReconcileFinalizer(obj client.Object, shouldHaveFinalizer bool) func() error {
+	return func() error {
+		return r.reconcileFinalizer(obj, shouldHaveFinalizer)
+	}
+}
+
 func (r *IngressReconciler) reconcileFinalizer(obj client.Object, shouldHaveFinalizer bool) error {
+	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	if err := r.Get(context.Background(), key, obj); err != nil {
+		return fmt.Errorf("fetching current Ingress: %v", err)
+	}
+
 	if shouldHaveFinalizer {
 		controllerutil.AddFinalizer(obj, cdnFinalizer)
 	} else {
 		controllerutil.RemoveFinalizer(obj, cdnFinalizer)
 	}
+
 	return r.Client.Update(context.Background(), obj)
 }
 
@@ -308,6 +330,8 @@ func (r *IngressReconciler) deleteDistribution(cdnStatus *v1alpha1.CDNStatus, bu
 	if err != nil {
 		return cloudfront.Distribution{}, fmt.Errorf("building desired distribution: %v", err)
 	}
+
+	r.log.V(1).Info("Disabling and deleting distribution on AWS, this may take a few minutes.")
 	return dist, r.DistRepo.Delete(dist)
 }
 
@@ -359,10 +383,6 @@ func (r *IngressReconciler) createCDNStatus(dist cloudfront.Distribution, group 
 		return nil, err
 	}
 	return cdnStatus, nil
-}
-
-func (r *IngressReconciler) updateCDNStatus(status *v1alpha1.CDNStatus) error {
-	return r.Status().Update(context.Background(), status)
 }
 
 func (r *IngressReconciler) handleFailure(err error, ingress client.Object, status *v1alpha1.CDNStatus) error {

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -19,6 +19,8 @@
 
 package cloudfront
 
+import "github.com/Gympass/cdn-origin-controller/internal/strhelper"
+
 const (
 	defaultResponseTimeout = 30
 )
@@ -50,20 +52,26 @@ type Behavior struct {
 
 // OriginBuilder allows the construction of a Origin
 type OriginBuilder struct {
-	origin        Origin
+	host          string
 	viewerFnARN   string
 	requestPolicy string
 	respTimeout   int64
+	paths         strhelper.Set
 }
 
 // NewOriginBuilder returns an OriginBuilder for a given host
 func NewOriginBuilder(host string) OriginBuilder {
-	return OriginBuilder{origin: Origin{Host: host, ResponseTimeout: defaultResponseTimeout}, requestPolicy: allViewerOriginRequestPolicyID}
+	return OriginBuilder{
+		host:          host,
+		respTimeout:   defaultResponseTimeout,
+		requestPolicy: allViewerOriginRequestPolicyID,
+		paths:         strhelper.NewSet(),
+	}
 }
 
 // WithBehavior adds a Behavior to the Origin being built given a path pattern the Behavior should respond for
 func (b OriginBuilder) WithBehavior(pathPattern string) OriginBuilder {
-	b.origin.Behaviors = append(b.origin.Behaviors, Behavior{PathPattern: pathPattern})
+	b.paths.Add(pathPattern)
 	return b
 }
 
@@ -83,32 +91,47 @@ func (b OriginBuilder) WithRequestPolicy(policy string) OriginBuilder {
 
 // WithResponseTimeout associates a custom response timeout to custom origin
 func (b OriginBuilder) WithResponseTimeout(rpTimeout int64) OriginBuilder {
-	b.respTimeout = rpTimeout
+	if rpTimeout > 0 {
+		b.respTimeout = rpTimeout
+	}
 	return b
 }
 
 // Build creates an Origin based on configuration made so far
 func (b OriginBuilder) Build() Origin {
+	origin := Origin{
+		Host:            b.host,
+		ResponseTimeout: b.respTimeout,
+	}
+
+	origin = b.addBehaviors(origin)
+
 	if len(b.viewerFnARN) > 0 {
-		b.addViewerFnToBehaviors()
+		origin = b.addViewerFnToBehaviors(origin)
 	}
 
-	b.addRequestPolicyToBehaviors()
+	origin = b.addRequestPolicyToBehaviors(origin)
 
-	if b.respTimeout > 0 {
-		b.origin.ResponseTimeout = b.respTimeout
-	}
-	return b.origin
+	return origin
 }
 
-func (b OriginBuilder) addViewerFnToBehaviors() {
-	for i := range b.origin.Behaviors {
-		b.origin.Behaviors[i].ViewerFnARN = b.viewerFnARN
+func (b OriginBuilder) addBehaviors(origin Origin) Origin {
+	for _, p := range b.paths.ToSlice() {
+		origin.Behaviors = append(origin.Behaviors, Behavior{PathPattern: p})
 	}
+	return origin
 }
 
-func (b OriginBuilder) addRequestPolicyToBehaviors() {
-	for i := range b.origin.Behaviors {
-		b.origin.Behaviors[i].RequestPolicy = b.requestPolicy
+func (b OriginBuilder) addViewerFnToBehaviors(origin Origin) Origin {
+	for i := range origin.Behaviors {
+		origin.Behaviors[i].ViewerFnARN = b.viewerFnARN
 	}
+	return origin
+}
+
+func (b OriginBuilder) addRequestPolicyToBehaviors(origin Origin) Origin {
+	for i := range origin.Behaviors {
+		origin.Behaviors[i].RequestPolicy = b.requestPolicy
+	}
+	return origin
 }

--- a/internal/cloudfront/origin_test.go
+++ b/internal/cloudfront/origin_test.go
@@ -61,6 +61,17 @@ func (s *OriginTestSuite) TestNewOriginBuilder_WithBehavior_MultipleBehaviors() 
 	s.Equal("/bar", o.Behaviors[2].PathPattern)
 }
 
+func (s *OriginTestSuite) TestNewOriginBuilder_WithBehavior_DuplicatePaths() {
+	o := NewOriginBuilder("origin").
+		WithBehavior("/").
+		WithBehavior("/").
+		Build()
+
+	s.Equal("origin", o.Host)
+	s.Len(o.Behaviors, 1)
+	s.Equal("/", o.Behaviors[0].PathPattern)
+}
+
 func (s *OriginTestSuite) TestNewOriginBuilder_WithViewerFunction() {
 	o := NewOriginBuilder("origin").
 		WithBehavior("/").

--- a/internal/cloudfront/origin_test.go
+++ b/internal/cloudfront/origin_test.go
@@ -56,9 +56,19 @@ func (s *OriginTestSuite) TestNewOriginBuilder_WithBehavior_MultipleBehaviors() 
 		Build()
 	s.Equal("origin", o.Host)
 	s.Len(o.Behaviors, 3)
-	s.Equal("/*", o.Behaviors[0].PathPattern)
-	s.Equal("/foo", o.Behaviors[1].PathPattern)
-	s.Equal("/bar", o.Behaviors[2].PathPattern)
+
+	gotPaths := []string{
+		o.Behaviors[0].PathPattern,
+		o.Behaviors[1].PathPattern,
+		o.Behaviors[2].PathPattern,
+	}
+	expectedPaths := []string{
+		"/*",
+		"/foo",
+		"/bar",
+	}
+
+	s.ElementsMatch(expectedPaths, gotPaths)
 }
 
 func (s *OriginTestSuite) TestNewOriginBuilder_WithBehavior_DuplicatePaths() {

--- a/internal/strhelper/strings.go
+++ b/internal/strhelper/strings.go
@@ -19,6 +19,31 @@
 
 package strhelper
 
+// Set represents a set of strings
+type Set map[string]bool
+
+// NewSet initializes and returns a new Set
+func NewSet() Set { return make(map[string]bool) }
+
+// Add ensures a given string is part of the Set
+func (ss Set) Add(s string) {
+	ss[s] = true
+}
+
+// Contains returns whether s is part of the Set
+func (ss Set) Contains(s string) bool {
+	return ss[s]
+}
+
+// ToSlice takes all elements of the set and assigns them to a []string
+func (ss Set) ToSlice() []string {
+	var result []string
+	for key := range ss {
+		result = append(result, key)
+	}
+	return result
+}
+
 // Contains check if string exists in given slice
 func Contains(s []string, e string) bool {
 	for _, a := range s {

--- a/internal/strhelper/strings_test.go
+++ b/internal/strhelper/strings_test.go
@@ -1,0 +1,43 @@
+package strhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestStringHelpersTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &StringHelpersTestSuite{})
+}
+
+type StringHelpersTestSuite struct {
+	suite.Suite
+}
+
+func (s *StringHelpersTestSuite) TestSet_Add() {
+	ss := NewSet()
+	ss.Add("test-1")
+	ss.Add("test-2")
+
+	s.True(ss["test-1"])
+	s.True(ss["test-2"])
+}
+
+func (s *StringHelpersTestSuite) TestSet_Contains() {
+	ss := NewSet()
+	ss.Add("test-1")
+	ss.Add("test-2")
+
+	s.True(ss.Contains("test-1"))
+	s.True(ss.Contains("test-2"))
+	s.False(ss.Contains("some other string"))
+}
+
+func (s *StringHelpersTestSuite) TestSet_ToSlice() {
+	ss := NewSet()
+	ss.Add("test-1")
+	ss.Add("test-2")
+
+	s.ElementsMatch([]string{"test-1", "test-2"}, ss.ToSlice())
+}

--- a/internal/strhelper/strings_test.go
+++ b/internal/strhelper/strings_test.go
@@ -1,3 +1,22 @@
+// Copyright (c) 2021 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package strhelper
 
 import (


### PR DESCRIPTION
To prevent them from reaching the AWS API duplicated, which triggers an error.

Also fixed a couple of bugs on the deletion flow:
  - one which would prevent the finalizer from being removed due to Ingress update conflict
  - one which would attempt to update the CDNStatus after deleting it