### PR TITLE
[RN-302] Add tests to internal/route53 package

### DIFF
--- a/internal/route53/alias.go
+++ b/internal/route53/alias.go
@@ -27,24 +27,14 @@ import (
 
 // Entry represents an alias entry with all desired record types for it
 type Entry struct {
-	Name string
-	Type []string
+	Name  string
+	Types []string
 }
 
 // Aliases represents all aliases which should be bound to a CF distribution
 type Aliases struct {
 	Target  string
 	Entries []Entry
-}
-
-// Domains returns a slice of all domains from an Aliases' Entries
-func (a Aliases) Domains() []string {
-	var domains []string
-
-	for _, e := range a.Entries {
-		domains = append(domains, e.Name)
-	}
-	return domains
 }
 
 // NewAliases builds a new Aliases
@@ -60,14 +50,24 @@ func NewAliases(target string, domains []string, ipv6Enabled bool) Aliases {
 
 	for _, domain := range domains {
 		entry := Entry{
-			Name: normalizeDomain(domain),
-			Type: types,
+			Name:  normalizeDomain(domain),
+			Types: types,
 		}
 
 		aliases.Entries = append(aliases.Entries, entry)
 	}
 
 	return aliases
+}
+
+// Domains returns a slice of all domains from an Aliases' Entries
+func (a Aliases) Domains() []string {
+	var domains []string
+
+	for _, e := range a.Entries {
+		domains = append(domains, e.Name)
+	}
+	return domains
 }
 
 // NormalizeDomains adds a "." at the end of each domain in the domains slice if not present already.

--- a/internal/route53/alias_test.go
+++ b/internal/route53/alias_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2022 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package route53_test
+
+import (
+	"testing"
+
+	awsroute53 "github.com/aws/aws-sdk-go/service/route53"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Gympass/cdn-origin-controller/internal/route53"
+)
+
+func TestRunAliasesTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &AliasesTestSuite{})
+}
+
+type AliasesTestSuite struct {
+	suite.Suite
+}
+
+func (s *AliasesTestSuite) TestNewAliases_IPV6Disabled() {
+	ipv6Enabled := false
+	target := "target.foo.bar."
+	domains := []string{"alias.foo.bar."}
+
+	aliases := route53.NewAliases(target, domains, ipv6Enabled)
+	s.Equal(target, aliases.Target)
+	s.Len(aliases.Entries, 1)
+	s.Equal(domains[0], aliases.Entries[0].Name)
+	s.ElementsMatch(aliases.Entries[0].Types, []string{awsroute53.RRTypeA})
+}
+
+func (s *AliasesTestSuite) TestNewAliases_IPV6Enabled() {
+	ipv6Enabled := true
+	target := "target.foo.bar."
+	domains := []string{"alias.foo.bar."}
+
+	aliases := route53.NewAliases(target, domains, ipv6Enabled)
+	s.Equal(target, aliases.Target)
+	s.Len(aliases.Entries, 1)
+	s.Equal(domains[0], aliases.Entries[0].Name)
+	s.ElementsMatch(aliases.Entries[0].Types, []string{awsroute53.RRTypeA, awsroute53.RRTypeAaaa})
+}
+
+func (s *AliasesTestSuite) TestNewAliases_MultipleAliases() {
+	ipv6Enabled := false
+	target := "target.foo.bar."
+	domains := []string{"alias1.foo.bar.", "alias2.foo.bar."}
+
+	aliases := route53.NewAliases(target, domains, ipv6Enabled)
+	s.Equal(target, aliases.Target)
+
+	expectedEntries := []route53.Entry{
+		{
+			Name:  "alias1.foo.bar.",
+			Types: []string{awsroute53.RRTypeA},
+		},
+		{
+			Name:  "alias2.foo.bar.",
+			Types: []string{awsroute53.RRTypeA},
+		},
+	}
+	s.ElementsMatch(expectedEntries, aliases.Entries)
+}
+
+func (s *AliasesTestSuite) TestNewAliases_DenormalizedInputDomains() {
+	ipv6Enabled := false
+	target := "target.foo.bar."
+	domains := []string{"alias1.foo.bar", "alias2.foo.bar"}
+
+	aliases := route53.NewAliases(target, domains, ipv6Enabled)
+	s.Equal(target, aliases.Target)
+
+	expectedEntries := []route53.Entry{
+		{
+			Name:  "alias1.foo.bar.",
+			Types: []string{awsroute53.RRTypeA},
+		},
+		{
+			Name:  "alias2.foo.bar.",
+			Types: []string{awsroute53.RRTypeA},
+		},
+	}
+	s.ElementsMatch(expectedEntries, aliases.Entries)
+}
+
+func (s *AliasesTestSuite) TestDomains() {
+	testCases := []struct {
+		name            string
+		expectedDomains []string
+	}{
+		{
+			"No domains configured",
+			nil,
+		},
+		{
+			"Multiple domains configured",
+			[]string{"alias1.foo.bar.", "alias2.foo.bar."},
+		},
+	}
+
+	for _, tc := range testCases {
+		aliases := route53.NewAliases("target.foo.bar.", tc.expectedDomains, false)
+		s.ElementsMatch(tc.expectedDomains, aliases.Domains(), "test: %s", tc.name)
+	}
+}
+
+func TestRunAliasTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &AliasTestSuite{})
+}
+
+type AliasTestSuite struct {
+	suite.Suite
+}
+
+func (s *AliasTestSuite) TestNormalizeDomains() {
+	testCases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Empty input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "Inputs have a '.' at the end",
+			input:    []string{"alias1.foo.bar.", "alias2.foo.bar."},
+			expected: []string{"alias1.foo.bar.", "alias2.foo.bar."},
+		},
+		{
+			name:     "Part of inputs don't have a '.' at the end",
+			input:    []string{"alias1.foo.bar.", "alias2.foo.bar"},
+			expected: []string{"alias1.foo.bar.", "alias2.foo.bar."},
+		},
+		{
+			name:     "No inputs have a '.' at the end",
+			input:    []string{"alias1.foo.bar", "alias2.foo.bar"},
+			expected: []string{"alias1.foo.bar.", "alias2.foo.bar."},
+		},
+	}
+
+	for _, tc := range testCases {
+		normalized := route53.NormalizeDomains(tc.input)
+		s.ElementsMatch(normalized, tc.expected, "test: %s", tc.name)
+	}
+}

--- a/internal/route53/repository_test.go
+++ b/internal/route53/repository_test.go
@@ -20,10 +20,48 @@
 package route53_test
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	awsroute53 "github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/Gympass/cdn-origin-controller/internal/config"
+	"github.com/Gympass/cdn-origin-controller/internal/route53"
 )
+
+const (
+	cfHostedZoneID               = "Z2FDTNDATAQYW2"
+	numberOfSupportedRecordTypes = "13"
+	txtOwnerKey                  = "cdn-origin-controller/owner"
+)
+
+type awsClientMock struct {
+	mock.Mock
+	route53iface.Route53API
+
+	ExpectedListRSSOutForTXTRecord      *awsroute53.ListResourceRecordSetsOutput
+	ExpectedListRRSOutForAddressRecords *awsroute53.ListResourceRecordSetsOutput
+}
+
+func (m *awsClientMock) ChangeResourceRecordSets(in *awsroute53.ChangeResourceRecordSetsInput) (*awsroute53.ChangeResourceRecordSetsOutput, error) {
+	args := m.Called(in)
+	return nil, args.Error(0) // we discard the out and only care about the error, no need to mock it
+}
+
+func (m *awsClientMock) ListResourceRecordSets(in *awsroute53.ListResourceRecordSetsInput) (*awsroute53.ListResourceRecordSetsOutput, error) {
+	args := m.Called(in)
+
+	result := m.ExpectedListRSSOutForTXTRecord
+	if in.StartRecordType == nil {
+		result = m.ExpectedListRRSOutForAddressRecords
+	}
+
+	return result, args.Error(0)
+}
 
 func TestRunAliasRepositoryTestSuite(t *testing.T) {
 	t.Parallel()
@@ -32,4 +70,741 @@ func TestRunAliasRepositoryTestSuite(t *testing.T) {
 
 type AliasRepositoryTestSuite struct {
 	suite.Suite
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_NoEntriesOnAliases() {
+	r := route53.NewAliasRepository(&awsClientMock{}, config.Config{})
+	a := route53.NewAliases("target.foo.bar.", nil, false)
+	s.NoError(r.Upsert(a))
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_FailureListingAddressRecords() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(errors.New("mock err")).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	err := repo.Upsert(aliases)
+	s.Error(err)
+	s.Contains(err.Error(), "mock err")
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_FailureListingTXTRecord() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: nil, // we're mocking when there are no existing records
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(errors.New("mock err")).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	err := repo.Upsert(aliases)
+	s.Error(err)
+	s.Contains(err.Error(), "mock err")
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_EntriesDontExist() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: nil, // we're mocking when there are no existing records
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: nil, // we're mocking when there are no existing records
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	expectedChangeRRSInput := &awsroute53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zone id"),
+		ChangeBatch: &awsroute53.ChangeBatch{
+			Changes: []*awsroute53.Change{
+				{ // A record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionUpsert),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeA),
+						AliasTarget: &awsroute53.AliasTarget{
+							DNSName:              aws.String("target.foo.bar."),
+							EvaluateTargetHealth: aws.Bool(false),
+							HostedZoneId:         aws.String(cfHostedZoneID),
+						},
+					},
+				},
+				{ // TXT record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionUpsert),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeTxt),
+						TTL:  aws.Int64(300),
+						ResourceRecords: []*awsroute53.ResourceRecord{
+							{
+								Value: aws.String(`"cdn-origin-controller/owner=owner value"`),
+							},
+						},
+					},
+				},
+			},
+			Comment: aws.String("Upserting Alias for CloudFront distribution managed by cdn-origin-controller"),
+		},
+	}
+	mockClient.On("ChangeResourceRecordSets", expectedChangeRRSInput).Return(noError).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	s.NoError(repo.Upsert(aliases))
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_TXTExists_HasOtherValues() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: nil, // we're mocking when there are no existing records
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeTxt),
+				TTL:  aws.Int64(300),
+				ResourceRecords: []*awsroute53.ResourceRecord{
+					{
+						Value: aws.String("some other value"),
+					},
+				},
+			},
+		},
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	expectedChangeRRSInput := &awsroute53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zone id"),
+		ChangeBatch: &awsroute53.ChangeBatch{
+			Changes: []*awsroute53.Change{
+				{ // A record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionUpsert),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeA),
+						AliasTarget: &awsroute53.AliasTarget{
+							DNSName:              aws.String("target.foo.bar."),
+							EvaluateTargetHealth: aws.Bool(false),
+							HostedZoneId:         aws.String(cfHostedZoneID),
+						},
+					},
+				},
+				{ // TXT record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionUpsert),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeTxt),
+						TTL:  aws.Int64(300),
+						ResourceRecords: []*awsroute53.ResourceRecord{
+							{
+								Value: aws.String("some other value"),
+							},
+							{
+								Value: aws.String(`"cdn-origin-controller/owner=owner value"`),
+							},
+						},
+					},
+				},
+			},
+			Comment: aws.String("Upserting Alias for CloudFront distribution managed by cdn-origin-controller"),
+		},
+	}
+	mockClient.On("ChangeResourceRecordSets", expectedChangeRRSInput).Return(noError).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	s.NoError(repo.Upsert(aliases))
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_AddressRecordsExist_OwnedByNoClass() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeA),
+				TTL:  aws.Int64(300),
+				ResourceRecords: []*awsroute53.ResourceRecord{
+					{
+						Value: aws.String("10.0.0.1"),
+					},
+				},
+			},
+		},
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: nil, // we're mocking when there's no ownership record
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	err := repo.Upsert(aliases)
+	s.Error(err)
+	s.Contains(err.Error(), "address record (A or AAAA) exists but is not managed by the controller")
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_RecordsExist_OwnedByAnotherClass() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeA),
+				TTL:  aws.Int64(300),
+				AliasTarget: &awsroute53.AliasTarget{
+					DNSName:              aws.String("another-target.foo.bar."),
+					EvaluateTargetHealth: aws.Bool(false),
+					HostedZoneId:         aws.String(cfHostedZoneID),
+				},
+			},
+		},
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeTxt),
+				TTL:  aws.Int64(300),
+				ResourceRecords: []*awsroute53.ResourceRecord{
+					{
+						Value: aws.String(txtOwnerKey + "=another owner class"),
+					},
+				},
+			},
+		},
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	err := repo.Upsert(aliases)
+	s.Error(err)
+	s.Contains(err.Error(), "is managed by another CDN class")
+}
+
+func (s *AliasRepositoryTestSuite) TestUpsert_RecordsExist_AlreadyOwnedByThisClass() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeA),
+				TTL:  aws.Int64(300),
+				AliasTarget: &awsroute53.AliasTarget{
+					DNSName:              aws.String("target.foo.bar."),
+					EvaluateTargetHealth: aws.Bool(false),
+					HostedZoneId:         aws.String(cfHostedZoneID),
+				},
+			},
+		},
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeTxt),
+				TTL:  aws.Int64(300),
+				ResourceRecords: []*awsroute53.ResourceRecord{
+					{
+						Value: aws.String("some other value"),
+					},
+					{
+						Value: aws.String(`"cdn-origin-controller/owner=owner value"`),
+					},
+				},
+			},
+		},
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	expectedChangeRRSInput := &awsroute53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zone id"),
+		ChangeBatch: &awsroute53.ChangeBatch{
+			Changes: []*awsroute53.Change{
+				{ // A record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionUpsert),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeA),
+						AliasTarget: &awsroute53.AliasTarget{
+							DNSName:              aws.String("target.foo.bar."),
+							EvaluateTargetHealth: aws.Bool(false),
+							HostedZoneId:         aws.String(cfHostedZoneID),
+						},
+					},
+				},
+				{ // TXT record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionUpsert),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeTxt),
+						TTL:  aws.Int64(300),
+						ResourceRecords: []*awsroute53.ResourceRecord{
+							{
+								Value: aws.String("some other value"),
+							},
+							{
+								Value: aws.String(`"cdn-origin-controller/owner=owner value"`),
+							},
+						},
+					},
+				},
+			},
+			Comment: aws.String("Upserting Alias for CloudFront distribution managed by cdn-origin-controller"),
+		},
+	}
+	mockClient.On("ChangeResourceRecordSets", expectedChangeRRSInput).Return(noError).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	s.NoError(repo.Upsert(aliases))
+}
+
+func (s *AliasRepositoryTestSuite) TestDelete_NoEntriesOnAliases() {
+	r := route53.NewAliasRepository(&awsClientMock{}, config.Config{})
+	a := route53.NewAliases("target.foo.bar.", nil, false)
+	s.NoError(r.Delete(a))
+}
+
+func (s *AliasRepositoryTestSuite) TestDelete_FailureListingRecords() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(errors.New("mock err")).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	err := repo.Delete(aliases)
+	s.Error(err)
+	s.Contains(err.Error(), "mock err")
+}
+
+func (s *AliasRepositoryTestSuite) TestDelete_RecordsDontExist() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: nil,
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: nil,
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	s.EqualError(repo.Delete(aliases), "ownership TXT record (alias.foo.bar.) not found, can't delete address records")
+}
+
+func (s *AliasRepositoryTestSuite) TestDelete_RecordsExist_TXTHasNoAdditionalValues() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeA),
+				TTL:  aws.Int64(300),
+				AliasTarget: &awsroute53.AliasTarget{
+					DNSName:              aws.String("target.foo.bar."),
+					EvaluateTargetHealth: aws.Bool(false),
+					HostedZoneId:         aws.String(cfHostedZoneID),
+				},
+			},
+		},
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeTxt),
+				TTL:  aws.Int64(300),
+				ResourceRecords: []*awsroute53.ResourceRecord{
+					{
+						Value: aws.String(`"cdn-origin-controller/owner=owner value"`),
+					},
+				},
+			},
+		},
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	expectedChangeRRSInput := &awsroute53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zone id"),
+		ChangeBatch: &awsroute53.ChangeBatch{
+			Changes: []*awsroute53.Change{
+				{ // A record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionDelete),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeA),
+						AliasTarget: &awsroute53.AliasTarget{
+							DNSName:              aws.String("target.foo.bar."),
+							EvaluateTargetHealth: aws.Bool(false),
+							HostedZoneId:         aws.String(cfHostedZoneID),
+						},
+					},
+				},
+				{ // TXT record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionDelete),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeTxt),
+						TTL:  aws.Int64(300),
+						ResourceRecords: []*awsroute53.ResourceRecord{
+							{
+								Value: aws.String(`"cdn-origin-controller/owner=owner value"`),
+							},
+						},
+					},
+				},
+			},
+			Comment: aws.String("Deleting Alias for CloudFront distribution managed by cdn-origin-controller"),
+		},
+	}
+	mockClient.On("ChangeResourceRecordSets", expectedChangeRRSInput).Return(noError).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	s.NoError(repo.Delete(aliases))
+}
+
+func (s *AliasRepositoryTestSuite) TestDelete_RecordsExist_TXTHasAdditionalValues() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeA),
+				TTL:  aws.Int64(300),
+				AliasTarget: &awsroute53.AliasTarget{
+					DNSName:              aws.String("target.foo.bar."),
+					EvaluateTargetHealth: aws.Bool(false),
+					HostedZoneId:         aws.String(cfHostedZoneID),
+				},
+			},
+		},
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeTxt),
+				TTL:  aws.Int64(300),
+				ResourceRecords: []*awsroute53.ResourceRecord{
+					{
+						Value: aws.String("some other value"),
+					},
+					{
+						Value: aws.String(`"cdn-origin-controller/owner=owner value"`),
+					},
+				},
+			},
+		},
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	expectedChangeRRSInput := &awsroute53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zone id"),
+		ChangeBatch: &awsroute53.ChangeBatch{
+			Changes: []*awsroute53.Change{
+				{ // A record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionDelete),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeA),
+						AliasTarget: &awsroute53.AliasTarget{
+							DNSName:              aws.String("target.foo.bar."),
+							EvaluateTargetHealth: aws.Bool(false),
+							HostedZoneId:         aws.String(cfHostedZoneID),
+						},
+					},
+				},
+				{ // TXT record for alias.foo.bar.
+					Action: aws.String(awsroute53.ChangeActionUpsert),
+					ResourceRecordSet: &awsroute53.ResourceRecordSet{
+						Name: aws.String("alias.foo.bar."),
+						Type: aws.String(awsroute53.RRTypeTxt),
+						TTL:  aws.Int64(300),
+						ResourceRecords: []*awsroute53.ResourceRecord{
+							{
+								Value: aws.String("some other value"),
+							},
+						},
+					},
+				},
+			},
+			Comment: aws.String("Deleting Alias for CloudFront distribution managed by cdn-origin-controller"),
+		},
+	}
+	mockClient.On("ChangeResourceRecordSets", expectedChangeRRSInput).Return(noError).Once()
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	s.NoError(repo.Delete(aliases))
+}
+
+func (s *AliasRepositoryTestSuite) TestDelete_RecordsExist_TXTNotOwnedByThisClass() {
+	cfg := config.Config{
+		CloudFrontRoute53TxtOwnerValue: "owner value",
+		CloudFrontRoute53HostedZoneID:  "zone id",
+	}
+	mockClient := &awsClientMock{}
+
+	expectedListRRSInputForAddresses := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String(numberOfSupportedRecordTypes),
+	}
+	expectedListRRSOutputForAddresses := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeA),
+				TTL:  aws.Int64(300),
+				AliasTarget: &awsroute53.AliasTarget{
+					DNSName:              aws.String("another-target.foo.bar."),
+					EvaluateTargetHealth: aws.Bool(false),
+					HostedZoneId:         aws.String(cfHostedZoneID),
+				},
+			},
+		},
+	}
+	var noError error
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForAddresses).Return(noError).Once()
+	mockClient.ExpectedListRRSOutForAddressRecords = expectedListRRSOutputForAddresses
+
+	expectedListRRSInputForTXT := &awsroute53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(cfg.CloudFrontRoute53HostedZoneID),
+		StartRecordName: aws.String("alias.foo.bar."),
+		MaxItems:        aws.String("1"),
+		StartRecordType: aws.String(awsroute53.RRTypeTxt),
+	}
+	expectedListRRSOutputForTXT := &awsroute53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []*awsroute53.ResourceRecordSet{
+			{
+				Name: aws.String("alias.foo.bar."),
+				Type: aws.String(awsroute53.RRTypeTxt),
+				TTL:  aws.Int64(300),
+				ResourceRecords: []*awsroute53.ResourceRecord{
+					{
+						Value: aws.String(txtOwnerKey + "=another owner class"),
+					},
+				},
+			},
+		},
+	}
+	mockClient.On("ListResourceRecordSets", expectedListRRSInputForTXT).Return(noError).Once()
+	mockClient.ExpectedListRSSOutForTXTRecord = expectedListRRSOutputForTXT
+
+	repo := route53.NewAliasRepository(mockClient, cfg)
+	aliases := route53.NewAliases("target.foo.bar.", []string{"alias.foo.bar."}, false)
+	err := repo.Delete(aliases)
+	s.Error(err)
+	s.Contains(err.Error(), "is managed by another CDN class")
 }

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func main() {
 		Client:    mgr.GetClient(),
 		Recorder:  mgr.GetEventRecorderFor("cdn-origin-controller"),
 		DistRepo:  cloudfront.NewDistributionRepository(awscloudfront.New(s), callerRefFn, waitTimeout),
-		AliasRepo: route53.NewRoute53AliasRepository(awsroute53.New(s), cfg),
+		AliasRepo: route53.NewAliasRepository(awsroute53.New(s), cfg),
 		Config:    cfg,
 	}
 


### PR DESCRIPTION
Increasing package coverage from 0% to 98.4% (missing 0.6% requires white box testing to be covered).

Signed-off-by: Lucas Caparelli <lucas.caparelli@gympass.com>