### PR TITLE
Setup dynamic leader election based on cdn class

### DIFF
--- a/charts/cdn-origin-controller/Chart.yaml
+++ b/charts/cdn-origin-controller/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-appVersion: "v0.0.10"
 description: The cdn-origin-controller Helm Chart
 name: cdn-origin-controller
-version: v0.0.12
+version: v0.0.13

--- a/charts/cdn-origin-controller/values.yaml
+++ b/charts/cdn-origin-controller/values.yaml
@@ -4,7 +4,7 @@ cdnClass: default
 
 image:
   repository: ghcr.io/gympass/cdn-origin-controller
-  tag: v0.0.9
+  tag: v0.0.11
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "19e16908.gympass.com",
+		LeaderElectionID:       leaderElectionID(cfg.CDNClass),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -134,6 +134,10 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func leaderElectionID(cdnClass string) string {
+	return fmt.Sprintf("%s.cdn-origin.gympass.com", cdnClass)
 }
 
 func mustSetupControllers(mgr manager.Manager, reconciler *controllers.IngressReconciler) {


### PR DESCRIPTION
To avoid leader election conflicts among COC deployments, we are defining a specific leader election ID per CDN class deployment.