### PR TITLE
[PE118] Bugfix: Update DNS status when syncing or not

### DIFF
--- a/api/v1alpha1/cdnstatus_types.go
+++ b/api/v1alpha1/cdnstatus_types.go
@@ -159,9 +159,10 @@ func (c *CDNStatus) GetIngressKeys() []client.ObjectKey {
 
 // SetDNSSync sets the DNS sync status if there is any DNS status to report
 func (c *CDNStatus) SetDNSSync(synced bool) {
-	if c.Status.DNS != nil {
-		c.Status.DNS.Synced = synced
+	if c.Status.DNS == nil {
+		c.Status.DNS = &DNSStatus{}
 	}
+	c.Status.DNS.Synced = synced
 }
 
 // SetInfo sets Distribution basic info

--- a/api/v1alpha1/cdnstatus_types.go
+++ b/api/v1alpha1/cdnstatus_types.go
@@ -33,7 +33,7 @@ import (
 // DNSStatus provides status regarding the creation of DNS records for aliases
 type DNSStatus struct {
 	Records []string `json:"records,omitempty"`
-	Synced  bool     `json:"synced,omitempty"`
+	Synced  bool     `json:"synced"`
 }
 
 // CDNStatusStatus defines the observed state of CDNStatus

--- a/config/crd/bases/cdn.gympass.com_cdnstatuses.yaml
+++ b/config/crd/bases/cdn.gympass.com_cdnstatuses.yaml
@@ -65,6 +65,8 @@ spec:
                     type: array
                   synced:
                     type: boolean
+                required:
+                - synced
                 type: object
               id:
                 type: string

--- a/internal/cloudfront/service.go
+++ b/internal/cloudfront/service.go
@@ -332,6 +332,8 @@ func (s *Service) handleSuccess(ingress client.Object, status *v1alpha1.CDNStatu
 	msg := "Successfully reconciled CDN"
 	s.Recorder.Event(ingress, corev1.EventTypeNormal, reasonSuccess, msg)
 
+	status.SetDNSSync(true)
+
 	ingRef := v1alpha1.NewIngressRef(ingress.GetNamespace(), ingress.GetName())
 	msg = fmt.Sprintf("%s: %s", ingRef, msg)
 	s.Recorder.Event(status, corev1.EventTypeNormal, reasonSuccess, msg)


### PR DESCRIPTION
Resolves gympass/production-engineering/issues/118

This PR aims to fix DNS sync status update

Changelog:

* Makes DNS status visible
* Instantiates DNSStatus when status is null
* Sets as successfully synced when process ends without error