### PR TITLE
feat(cloudfront): cloudfront tags configuration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->
+
+## Description
+<!--- Describe your changes -->
+
+## Motivation and Context
+<!--- If it fixes an open issue, please link to the issue here. -->
+<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
+
+## How has this been tested?
+<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
+<!--- If the changes are untested, please explicitly say so and explain why. -->
+
+## Checklist
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] I have implemented automated tests for the changes.
+- [ ] I have updated the documentation accordingly.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The following annotation controls how origins and behaviors are attached to Clou
 - `cdn-origin-controller.gympass.com/cf.origin-response-timeout`: the number of seconds that CloudFront waits for a response from the origin, from 1 to 60. Example: `"30"`
 - `cdn-origin-controller.gympass.com/cf.viewer-function-arn`: the ARN of the CloudFront function you would like to associate to viewer requests in each behavior managed by this Ingress. Example: `arn:aws:cloudfront::000000000000:function/my-function`
 - `cdn-origin-controller.gympass.com/cf.web-acl-arn`: A unique identifier that specifies the AWS WAF web ACL, if any, to associate with this distribution. To specify a web ACL created using the latest version of AWS WAF, use the ACL ARN, for example `arn:aws:wafv2:us-east-1:123456789012:global/webacl/ExampleWebACL/473e64fd-f30b-4765-81a0-62ad96dd167a`. To specify a web ACL created using AWS WAF Classic, use the ACL ID, for example `473e64fd-f30b-4765-81a0-62ad96dd167a`.
+- `cdn-origin-controller.gympass.com/cf.tags`: A map of key/value strings to be configured in Cloudfront distribution. The value of this annotation should be given as a YAML map. Example:
+  ```yaml
+  cdn-origin-controller.gympass.com/cf.tags: |
+    mykey1: myvalue1
+    mykey2: myvalue2
+  ```
 
 The controller needs permission to manipulate the CloudFront distributions. A [sample IAM Policy](docs/iam_policy.json) is provided with the necessary IAM actions.
 

--- a/controllers/ingress_v1_controller.go
+++ b/controllers/ingress_v1_controller.go
@@ -47,7 +47,7 @@ type V1Reconciler struct {
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses/status,verbs=get;update;patch
 
-//Reconcile a v1 Ingress resource
+// Reconcile a v1 Ingress resource
 func (r *V1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
 	log.Info("Starting reconciliation.")
@@ -63,9 +63,12 @@ func (r *V1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		return reconcile.Result{}, fmt.Errorf("could not fetch Ingress: %+v", err)
 	}
 
-	reconcilingCDNIngress := k8s.NewCDNIngressFromV1(ingress)
-	err = r.CloudFrontService.Reconcile(ctx, reconcilingCDNIngress, ingress)
+	reconcilingCDNIngress, err := k8s.NewCDNIngressFromV1(ingress)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
+	err = r.CloudFrontService.Reconcile(ctx, reconcilingCDNIngress, ingress)
 	if err == nil {
 		log.Info("Reconciliation successful.")
 	}

--- a/controllers/ingress_v1beta1_controller.go
+++ b/controllers/ingress_v1beta1_controller.go
@@ -47,7 +47,7 @@ type V1beta1Reconciler struct {
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cdn.gympass.com,resources=cdnstatuses/status,verbs=get;update;patch
 
-//Reconcile a v1beta1 Ingress resource
+// Reconcile a v1beta1 Ingress resource
 func (r *V1beta1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
 	log.Info("Starting reconciliation.")
@@ -63,7 +63,11 @@ func (r *V1beta1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return reconcile.Result{}, fmt.Errorf("could not fetch Ingress: %+v", err)
 	}
 
-	reconcilingCDNIngress := k8s.NewCDNIngressFromV1beta1(ingress)
+	reconcilingCDNIngress, err := k8s.NewCDNIngressFromV1beta1(ingress)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	err = r.CloudFrontService.Reconcile(ctx, reconcilingCDNIngress, ingress)
 	if err == nil {
 		log.Info("Reconciliation successful.")

--- a/internal/cloudfront/distribution.go
+++ b/internal/cloudfront/distribution.go
@@ -123,9 +123,9 @@ func (b DistributionBuilder) WithLogging(bucketAddress, prefix string) Distribut
 	return b
 }
 
-// WithTags takes in custom tags which should be present at the Distribution
-func (b DistributionBuilder) WithTags(tags map[string]string) DistributionBuilder {
-	b.tags = tags
+// AppendTags takes in custom tags which should be present at the Distribution
+func (b DistributionBuilder) AppendTags(tags map[string]string) DistributionBuilder {
+	b.tags = strhelper.MergeMapString(b.tags, tags)
 	return b
 }
 

--- a/internal/cloudfront/distribution_test.go
+++ b/internal/cloudfront/distribution_test.go
@@ -153,14 +153,27 @@ func (s *DistributionTestSuite) TestDistributionBuilder_WithCustomTags() {
 		"testKey2": "testValue2",
 	}
 
+	otherTags := map[string]string{
+		"testKey": "testValue",
+		"foo":     "bar",
+	}
+
 	dist, err := cloudfront.NewDistributionBuilder("domain", "description", "priceClass", "group", "default-web-acl").
-		WithTags(tags).
+		AppendTags(tags).
+		AppendTags(otherTags).
 		Build()
 
 	s.NoError(err)
-	for k, v := range tags {
-		s.Equal(v, dist.Tags[k], "key: %s\tvalue: %s", k, v)
+
+	expected := map[string]string{
+		"cdn-origin-controller.gympass.com/cdn.group": "group",
+		"cdn-origin-controller.gympass.com/owned":     "true",
+		"foo":      "bar",
+		"testKey":  "testValue",
+		"testKey2": "testValue2",
 	}
+
+	s.Equal(expected, dist.Tags)
 }
 
 func (s *DistributionTestSuite) TestDistributionBuilder_WithTLS() {

--- a/internal/cloudfront/repository_test.go
+++ b/internal/cloudfront/repository_test.go
@@ -167,7 +167,7 @@ func (s *DistributionRepositoryTestSuite) TestCreate_Success() {
 		WithOrigin(Origin{Host: "origin", ResponseTimeout: 30}).
 		WithAlternateDomains([]string{"test.alias.1", "test.alias.2"}).
 		WithWebACL("test web acl").
-		WithTags(map[string]string{"foo": "bar"}).
+		AppendTags(map[string]string{"foo": "bar"}).
 		WithLogging("test s3", "test prefix").
 		WithTLS("test:cert:arn", "test security policy").
 		WithIPv6().

--- a/internal/cloudfront/service.go
+++ b/internal/cloudfront/service.go
@@ -65,7 +65,7 @@ func (s *Service) Reconcile(ctx context.Context, reconciling k8s.CDNIngress, ing
 		return s.reconcileFinalizer(ing, false)
 	}
 
-	desiredIngresses, desiredDist, err := s.desiredState(ctx, reconciling, ing)
+	desiredIngresses, desiredDist, err := s.desiredState(ctx, reconciling)
 	if err != nil {
 		return fmt.Errorf("computing desired state: %v", err)
 	}
@@ -103,8 +103,8 @@ func (s *Service) Reconcile(ctx context.Context, reconciling k8s.CDNIngress, ing
 	return s.handleResult(ing, cdnStatus, errs)
 }
 
-func (s *Service) desiredState(ctx context.Context, reconciling k8s.CDNIngress, obj client.Object) ([]k8s.CDNIngress, Distribution, error) {
-	desiredIngresses, err := s.desiredIngresses(ctx, reconciling, obj)
+func (s *Service) desiredState(ctx context.Context, reconciling k8s.CDNIngress) ([]k8s.CDNIngress, Distribution, error) {
+	desiredIngresses, err := s.desiredIngresses(ctx, reconciling)
 	if err != nil {
 		return nil, Distribution{}, err
 	}
@@ -127,7 +127,7 @@ func (s *Service) desiredState(ctx context.Context, reconciling k8s.CDNIngress, 
 	return desiredIngresses, desiredDist, nil
 }
 
-func (s *Service) desiredIngresses(ctx context.Context, reconciling k8s.CDNIngress, obj client.Object) ([]k8s.CDNIngress, error) {
+func (s *Service) desiredIngresses(ctx context.Context, reconciling k8s.CDNIngress) ([]k8s.CDNIngress, error) {
 	desiredIngresses, err := s.Fetcher.FetchBy(ctx, s.isPartOfDesiredState(reconciling))
 	if err != nil {
 		return nil, fmt.Errorf("listing active Ingresses that belong to group %s: %v", reconciling.Group, err)

--- a/internal/cloudfront/service_helpers.go
+++ b/internal/cloudfront/service_helpers.go
@@ -42,6 +42,7 @@ func newDistribution(ingresses []k8s.CDNIngress, group, webACLARN, distARN strin
 	for _, ing := range ingresses {
 		b = b.WithOrigin(newOrigin(ing))
 		b = b.WithAlternateDomains(ing.AlternateDomainNames)
+		b = b.AppendTags(ing.Tags)
 	}
 
 	if cfg.CloudFrontEnableIPV6 {
@@ -57,7 +58,7 @@ func newDistribution(ingresses []k8s.CDNIngress, group, webACLARN, distARN strin
 	}
 
 	if len(cfg.CloudFrontCustomTags) > 0 {
-		b = b.WithTags(cfg.CloudFrontCustomTags)
+		b = b.AppendTags(cfg.CloudFrontCustomTags)
 	}
 
 	if len(webACLARN) > 0 {

--- a/internal/k8s/ingress_fetcher_v1.go
+++ b/internal/k8s/ingress_fetcher_v1.go
@@ -44,7 +44,10 @@ func (i ingFetcherV1) FetchBy(ctx context.Context, predicate func(CDNIngress) bo
 
 	var result []CDNIngress
 	for _, k8sIng := range list.Items {
-		ing := NewCDNIngressFromV1(&k8sIng)
+		ing, err := NewCDNIngressFromV1(&k8sIng)
+		if err != nil {
+			return result, err
+		}
 		if predicate(ing) {
 			result = append(result, ing)
 			userOriginsCDNIngresses, err := cdnIngressesForUserOrigins(&k8sIng)

--- a/internal/k8s/ingress_fetcher_v1_test.go
+++ b/internal/k8s/ingress_fetcher_v1_test.go
@@ -156,9 +156,10 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 			return ing.Group == "group"
 		}
 
-		expectedParentCDNIng := NewCDNIngressFromV1(parentIng)
-		expectedIngs := append(tc.expectedIngs, expectedParentCDNIng)
+		expectedParentCDNIng, err := NewCDNIngressFromV1(parentIng)
+		s.NoError(err, "test: %s", tc.name)
 
+		expectedIngs := append(tc.expectedIngs, expectedParentCDNIng)
 		gotIngs, err := fetcher.FetchBy(context.Background(), predicate)
 		s.NoError(err, "test: %s", tc.name)
 		s.ElementsMatch(expectedIngs, gotIngs, "test: %s", tc.name)

--- a/internal/k8s/ingress_fetcher_v1beta1.go
+++ b/internal/k8s/ingress_fetcher_v1beta1.go
@@ -44,7 +44,10 @@ func (i ingFetcherV1Beta1) FetchBy(ctx context.Context, predicate func(CDNIngres
 
 	var result []CDNIngress
 	for _, k8sIng := range list.Items {
-		ing := NewCDNIngressFromV1beta1(&k8sIng)
+		ing, err := NewCDNIngressFromV1beta1(&k8sIng)
+		if err != nil {
+			return result, err
+		}
 		if predicate(ing) {
 			result = append(result, ing)
 			userOriginsCDNIngresses, err := cdnIngressesForUserOrigins(&k8sIng)

--- a/internal/k8s/ingress_fetcher_v1beta1_test.go
+++ b/internal/k8s/ingress_fetcher_v1beta1_test.go
@@ -181,9 +181,10 @@ func (s *IngressFetcherV1Beta1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 			return ing.Group == "group"
 		}
 
-		expectedParentCDNIng := NewCDNIngressFromV1beta1(parentIng)
-		expectedIngs := append(tc.expectedIngs, expectedParentCDNIng)
+		expectedParentCDNIng, err := NewCDNIngressFromV1beta1(parentIng)
+		s.NoError(err, "test: %s", tc.name)
 
+		expectedIngs := append(tc.expectedIngs, expectedParentCDNIng)
 		gotIngs, err := fetcher.FetchBy(context.Background(), predicate)
 		s.NoError(err, "test: %s", tc.name)
 		s.ElementsMatch(expectedIngs, gotIngs, "test: %s", tc.name)

--- a/internal/k8s/ingress_test.go
+++ b/internal/k8s/ingress_test.go
@@ -56,8 +56,34 @@ func (s *CDNIngressSuite) TestNewCDNIngressFromV1_WithAlternativeDomainNames() {
 			},
 		},
 	}
-	ip := NewCDNIngressFromV1(ing)
+	ip, _ := NewCDNIngressFromV1(ing)
 	s.Equal([]string{"banana.com.br", "pera.com.br"}, ip.AlternateDomainNames)
+}
+
+func (s *CDNIngressSuite) TestNewCDNIngressFromV1_WithValidTags() {
+	tags := `
+area: platform
+product-domain: operators
+foo: bar
+`
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Annotations: map[string]string{
+				"cdn-origin-controller.gympass.com/cf.tags": tags,
+			},
+		},
+	}
+
+	expected := map[string]string{
+		"area":           "platform",
+		"product-domain": "operators",
+		"foo":            "bar",
+	}
+
+	ip, _ := NewCDNIngressFromV1(ing)
+	s.Equal(expected, ip.Tags)
 }
 
 func (s *CDNIngressSuite) Test_sharedIngressParams_Valid() {

--- a/internal/strhelper/strings.go
+++ b/internal/strhelper/strings.go
@@ -66,3 +66,17 @@ func Filter(s []string, predicate func(string) bool) []string {
 	}
 	return filtered
 }
+
+// MergeMapString merge two maps in a new one
+func MergeMapString(m1, m2 map[string]string) map[string]string {
+	nm := make(map[string]string)
+
+	for k, v := range m1 {
+		nm[k] = v
+	}
+
+	for k, v := range m2 {
+		nm[k] = v
+	}
+	return nm
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->
## Description

This new feature allows the configuration of custom tags for CloudFront distribution.
Tags configured between multiple entries will be merged.

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cdn-origin-controller.gympass.com/cf.tags: |
      foo: bar
      abc: bca
...
```
## How has this been tested?
- [x] Unit tests
- [x] manual tests

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [x] I have updated the documentation accordingly.