### PR TITLE
fix(Charts): adjusting charts to use the nameOverride

### DIFF
--- a/charts/cdn-origin-controller/templates/_helpers.tpl
+++ b/charts/cdn-origin-controller/templates/_helpers.tpl
@@ -3,7 +3,23 @@
 Expand the name of the chart.
 */}}
 {{- define "cdn-origin-controller.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.nameOverride -}}
+{{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Chart.Name  .Values.cdnClass  | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart without adding cdnClass value. This is used to maintain backwards
+compatibility with older clusters during the service account creation 
+*/}}
+{{- define "cdn-origin-controller.name-without-cdn-class" -}}
+{{- if .Values.nameOverride -}}
+{{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -49,7 +65,7 @@ Create the name of the service account to use
 */}}
 {{- define "cdn-origin-controller.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "cdn-origin-controller.name" .) .Values.serviceAccount.name }}
+    {{ default (include "cdn-origin-controller.name-without-cdn-class" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/charts/cdn-origin-controller/templates/deployment.yaml
+++ b/charts/cdn-origin-controller/templates/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+  name: {{ include "cdn-origin-controller.name" . }}
   labels:
 {{ include "cdn-origin-controller.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+      app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         {{- toYaml .Values.deployment.annotations | nindent 8 }}
       labels:
-        app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+        app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/charts/cdn-origin-controller/templates/role.yaml
+++ b/charts/cdn-origin-controller/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+  name: {{ include "cdn-origin-controller.name" . }}
 rules:
 - apiGroups:
   - ""

--- a/charts/cdn-origin-controller/templates/role_binding.yaml
+++ b/charts/cdn-origin-controller/templates/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+  name: {{ include "cdn-origin-controller.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+  name: {{ include "cdn-origin-controller.name" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "cdn-origin-controller.serviceAccountName" . }}

--- a/charts/cdn-origin-controller/templates/service.yaml
+++ b/charts/cdn-origin-controller/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+  name: {{ include "cdn-origin-controller.name" . }}
   labels:
 {{ include "cdn-origin-controller.labels" . | indent 4 }}
 spec:
@@ -12,5 +12,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}-{{ .Values.cdnClass }}
+    app.kubernetes.io/name: {{ include "cdn-origin-controller.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
This PR makes the following adjustments to helm charts: 	

1. Updated the cdn-origin-controller.name template function to if the nameOverride property was set on values.yaml. If it was the output will the value inserted. If not the output will be concatenation of the chart name with the CdnClass property (Like it was before).  
2. Included a cdn-origin-controller.name-without-cdn-class template function that does the same thing as cdn-origin-controller.name, but if a nameOverride is not set, the output does not concatenates Cdn Class. This function was included to maintain compatibility with the service-account-name function.
3. Removed the concatenation between resource name and cluster name in the templates because it’s already happening on the template functions.