### PR TITLE
[PE1-1248]  Add repository to manage Access Origin Control (AOC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25
+ENVTEST_K8S_VERSION = 1.27
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/internal/aws/error.go
+++ b/internal/aws/error.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+// IsErrorCode returns whether the give error matches an AWS error with the give errCode.
+// If the input error is not a valid awserr.Error, it returns false
+func IsErrorCode(err error, errCode string) bool {
+	var aerr awserr.Error
+	if ok := errors.As(err, &aerr); !ok {
+		return false
+	}
+	return aerr.Code() == errCode
+}
+
+// IgnoreErrorCode will return nil if the input error is a valid awserr.Error
+// matching the given errCode. It will return the input error as-is otherwise
+func IgnoreErrorCode(err error, errCode string) error {
+	if IsErrorCode(err, errCode) {
+		return nil
+	}
+	return err
+}
+
+// IgnoreErrorCodef will return nil if the input error is a valid awserr.Error
+// matching the given errCode. It will return the input error formatted with the given
+// format otherwise following fmt.Errorf behavior
+func IgnoreErrorCodef(format string, err error, errCode string) error {
+	if IsErrorCode(err, errCode) {
+		return nil
+	}
+	return fmt.Errorf(format, err)
+}

--- a/internal/aws/error.go
+++ b/internal/aws/error.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-// IsErrorCode returns whether the give error matches an AWS error with the give errCode.
+// IsErrorCode returns whether the given error matches an AWS error with the given errCode.
 // If the input error is not a valid awserr.Error, it returns false
 func IsErrorCode(err error, errCode string) bool {
 	var aerr awserr.Error

--- a/internal/aws/error.go
+++ b/internal/aws/error.go
@@ -1,3 +1,22 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package aws
 
 import (

--- a/internal/cloudfront/aoc_lister.go
+++ b/internal/cloudfront/aoc_lister.go
@@ -1,3 +1,22 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 package cloudfront
 
 import (

--- a/internal/cloudfront/aoc_lister.go
+++ b/internal/cloudfront/aoc_lister.go
@@ -1,0 +1,85 @@
+package cloudfront
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	awscloudfront "github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
+)
+
+// This entire file should be moved to the SDK if they accept a feature request.
+// It implements pagination for listing AOCs in the same style of other paginators
+// that are already implemented in the SDK. For example:
+// https://github.com/aws/aws-sdk-go/blob/v1.44.269/service/cloudfront/api.go#L6927
+
+// AOCLister lists AOCs.
+// Using an interface to make it more testable, since otherwise we'd need to create
+// fake requests, which can't be mocked because they are not interfaces.
+type AOCLister interface {
+	ListOriginAccessControlsPages(input *awscloudfront.ListOriginAccessControlsInput, fn func(*awscloudfront.ListOriginAccessControlsOutput, bool) bool) error
+	ListOriginAccessControlsPagesWithContext(ctx context.Context, input *awscloudfront.ListOriginAccessControlsInput, fn func(*awscloudfront.ListOriginAccessControlsOutput, bool) bool, opts ...request.Option) error
+}
+
+type aocLister struct {
+	client cloudfrontiface.CloudFrontAPI
+}
+
+func NewAOCLister(client cloudfrontiface.CloudFrontAPI) AOCLister {
+	return aocLister{client: client}
+}
+
+// ListOriginAccessControlsPages iterates over the pages of an awscloudfront.ListOriginAccessControlsInput operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See awscloudfront.ListOriginAccessControlsInput method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+// Note2: Ideally this would be implemented in the SDK directly, it isn't for now.
+//
+//	// Example iterating over at most 3 pages of an awscloudfront.ListOriginAccessControls operation.
+//	pageNum := 0
+//	err := client.ListOriginAccessControlsPages(params,
+//	    func(page *awscloudfront.ListOriginAccessControlsOutput, lastPage bool) bool {
+//	        pageNum++
+//	        fmt.Println(page)
+//	        return pageNum <= 3
+//	    })
+func (l aocLister) ListOriginAccessControlsPages(input *awscloudfront.ListOriginAccessControlsInput, fn func(*awscloudfront.ListOriginAccessControlsOutput, bool) bool) error {
+	return l.ListOriginAccessControlsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListOriginAccessControlsPagesWithContext same as ListOriginAccessControlsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// Note: Ideally this would be implemented in the SDK directly, it isn't for now.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (l aocLister) ListOriginAccessControlsPagesWithContext(ctx context.Context, input *awscloudfront.ListOriginAccessControlsInput, fn func(*awscloudfront.ListOriginAccessControlsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *awscloudfront.ListOriginAccessControlsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := l.client.ListOriginAccessControlsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	for p.Next() {
+		if !fn(p.Page().(*awscloudfront.ListOriginAccessControlsOutput), !p.HasNextPage()) {
+			break
+		}
+	}
+
+	return p.Err()
+}

--- a/internal/cloudfront/aoc_repository.go
+++ b/internal/cloudfront/aoc_repository.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cloudfront
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscloudfront "github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
+
+	cdnaws "github.com/Gympass/cdn-origin-controller/internal/aws"
+)
+
+var errNoSuchAOC = errors.New("aoc does not exist")
+
+type AOC struct {
+	ID                            string `json:"id"`
+	Name                          string `json:"name"`
+	OriginName                    string `json:"originName"`
+	OriginAccessControlOriginType string `json:"originAccessControlOriginType"`
+	SigningBehavior               string `json:"signingBehavior"`
+	SigningProtocol               string `json:"signingProtocol"`
+}
+
+type AOCRepository interface {
+	// Sync updates or creates a desired AOC. If successful, returns current AOC
+	Sync(desired AOC) (AOC, error)
+	// Delete deletes the AOC of given id. If successful, returns deleted AOC
+	Delete(toBeDeleted AOC) (AOC, error)
+}
+
+func NewAOCRepository(client cloudfrontiface.CloudFrontAPI, aocLister AOCLister) AOCRepository {
+	return aocRepository{client: client, aocLister: aocLister}
+}
+
+var _ AOCRepository = aocRepository{}
+
+type aocRepository struct {
+	client    cloudfrontiface.CloudFrontAPI
+	aocLister AOCLister
+}
+
+func (r aocRepository) Sync(desired AOC) (AOC, error) {
+	observed, err := r.getAOC(desired)
+	if err == nil {
+		return r.updateAOC(desired, observed)
+	}
+
+	if errors.Is(err, errNoSuchAOC) {
+		return r.createAOC(desired)
+	}
+
+	return AOC{}, fmt.Errorf("fetching existing AOC: %v", err)
+}
+
+func (r aocRepository) Delete(toBeDeleted AOC) (AOC, error) {
+	existingAOC, err := r.getAOC(toBeDeleted)
+	if err != nil {
+		return AOC{}, ignoreNoSuchAOC(err)
+	}
+
+	_, err = r.client.DeleteOriginAccessControl(&awscloudfront.DeleteOriginAccessControlInput{
+		Id: aws.String(existingAOC.ID),
+	})
+	if cdnaws.IgnoreErrorCode(err, awscloudfront.ErrCodeNoSuchOriginAccessControl) != nil {
+		return AOC{}, err
+	}
+
+	return existingAOC, nil
+}
+
+func (r aocRepository) createAOC(desired AOC) (AOC, error) {
+	out, err := r.client.CreateOriginAccessControl(
+		&awscloudfront.CreateOriginAccessControlInput{OriginAccessControlConfig: &awscloudfront.OriginAccessControlConfig{
+			Description:                   aws.String(fmt.Sprintf("AOC for %s, managed by cdn-desired-controller", desired.OriginName)),
+			Name:                          aws.String(desired.Name),
+			OriginAccessControlOriginType: aws.String(awscloudfront.OriginAccessControlOriginTypesS3),
+			SigningBehavior:               aws.String(awscloudfront.OriginAccessControlSigningBehaviorsAlways),
+			SigningProtocol:               aws.String(awscloudfront.OriginAccessControlSigningProtocolsSigv4),
+		}},
+	)
+	if err != nil {
+		return AOC{}, err
+	}
+
+	aoc := out.OriginAccessControl.OriginAccessControlConfig
+	return newAOCFromOriginAccessControlConfig(aoc, out.OriginAccessControl.Id, desired.OriginName), nil
+}
+
+func (r aocRepository) updateAOC(desired AOC, observed AOC) (AOC, error) {
+	out, err := r.client.UpdateOriginAccessControl(
+		&awscloudfront.UpdateOriginAccessControlInput{
+			Id: aws.String(observed.ID),
+			OriginAccessControlConfig: &awscloudfront.OriginAccessControlConfig{
+				Description:                   aws.String(fmt.Sprintf("AOC for %s, managed by cdn-desired-controller", desired.OriginName)),
+				Name:                          aws.String(desired.Name),
+				OriginAccessControlOriginType: aws.String(awscloudfront.OriginAccessControlOriginTypesS3),
+				SigningBehavior:               aws.String(awscloudfront.OriginAccessControlSigningBehaviorsAlways),
+				SigningProtocol:               aws.String(awscloudfront.OriginAccessControlSigningProtocolsSigv4),
+			}},
+	)
+	if err != nil {
+		return AOC{}, err
+	}
+
+	aoc := out.OriginAccessControl.OriginAccessControlConfig
+	return newAOCFromOriginAccessControlConfig(aoc, out.OriginAccessControl.Id, desired.OriginName), nil
+}
+
+func (r aocRepository) getAOC(aoc AOC) (AOC, error) {
+	input := &awscloudfront.ListOriginAccessControlsInput{}
+
+	var observed AOC
+	found := false
+
+	err := r.aocLister.ListOriginAccessControlsPages(input, func(output *awscloudfront.ListOriginAccessControlsOutput, lastPage bool) bool {
+		for _, item := range output.OriginAccessControlList.Items {
+			if aws.StringValue(item.Name) == aoc.Name {
+				observed = newAOCFromOriginAccessControlSummary(item, aoc.OriginName)
+				found = true
+				return false
+			}
+		}
+		return !lastPage
+	})
+
+	if err != nil {
+		return AOC{}, fmt.Errorf("listing AOCs: %v", err)
+	}
+
+	if !found {
+		return AOC{}, errNoSuchAOC
+	}
+
+	return observed, nil
+}
+
+func newAOCFromOriginAccessControlConfig(cfg *awscloudfront.OriginAccessControlConfig, id *string, originName string) AOC {
+	return AOC{
+		ID:                            aws.StringValue(id),
+		Name:                          aws.StringValue(cfg.Name),
+		OriginName:                    originName,
+		OriginAccessControlOriginType: aws.StringValue(cfg.OriginAccessControlOriginType),
+		SigningBehavior:               aws.StringValue(cfg.SigningBehavior),
+		SigningProtocol:               aws.StringValue(cfg.SigningProtocol),
+	}
+}
+
+func newAOCFromOriginAccessControlSummary(summary *awscloudfront.OriginAccessControlSummary, originName string) AOC {
+	return AOC{
+		ID:                            aws.StringValue(summary.Id),
+		Name:                          aws.StringValue(summary.Name),
+		OriginName:                    originName,
+		OriginAccessControlOriginType: aws.StringValue(summary.OriginAccessControlOriginType),
+		SigningBehavior:               aws.StringValue(summary.SigningBehavior),
+		SigningProtocol:               aws.StringValue(summary.SigningProtocol),
+	}
+}
+
+func ignoreNoSuchAOC(err error) error {
+	if errors.Is(err, errNoSuchAOC) {
+		return nil
+	}
+	return err
+}

--- a/internal/cloudfront/aoc_repository_test.go
+++ b/internal/cloudfront/aoc_repository_test.go
@@ -1,0 +1,360 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cloudfront
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	awscloudfront "github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Gympass/cdn-origin-controller/internal/test"
+)
+
+type aocListerMock struct {
+	mock.Mock
+	AOCLister
+	expectedPages []*awscloudfront.ListOriginAccessControlsOutput
+}
+
+func (m *aocListerMock) ListOriginAccessControlsPages(input *awscloudfront.ListOriginAccessControlsInput, fn func(*awscloudfront.ListOriginAccessControlsOutput, bool) bool) error {
+	args := m.Called(input, fn)
+	for i, expectedPage := range m.expectedPages {
+		isLastPage := len(m.expectedPages) == i+1
+		shouldContinue := fn(expectedPage, isLastPage)
+		if !shouldContinue {
+			break
+		}
+	}
+	return args.Error(0)
+}
+
+func TestRunAOCRepositoryTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &aocRepositorySuite{})
+}
+
+type aocRepositorySuite struct {
+	suite.Suite
+	client *test.MockCloudFrontAPI
+	lister *aocListerMock
+}
+
+func (s *aocRepositorySuite) SetupTest() {
+	s.client = &test.MockCloudFrontAPI{}
+	s.lister = &aocListerMock{}
+}
+
+func (s *aocRepositorySuite) TestSync_AOCWillBeCreatedAndOtherAOCsAlreadyExistShouldReturnNoError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+	s.lister.expectedPages = []*awscloudfront.ListOriginAccessControlsOutput{
+		{
+			OriginAccessControlList: &awscloudfront.OriginAccessControlList{Items: []*awscloudfront.OriginAccessControlSummary{
+				{
+					// we just want this to not match the name, the rest isn't important
+					// we want to ensure we go at least through one page
+					Id:   aws.String("id"),
+					Name: aws.String("another name"),
+				},
+			}},
+		},
+	}
+
+	s.client.On("CreateOriginAccessControl", mock.Anything).
+		Return(noError)
+	s.client.ExpectedCreateOriginAccessControlOutput = &awscloudfront.CreateOriginAccessControlOutput{
+		OriginAccessControl: &awscloudfront.OriginAccessControl{
+			Id: aws.String("id"),
+			OriginAccessControlConfig: &awscloudfront.OriginAccessControlConfig{
+				Name:                          aws.String("name"),
+				OriginAccessControlOriginType: aws.String(awscloudfront.OriginAccessControlOriginTypesS3),
+				SigningBehavior:               aws.String(awscloudfront.OriginAccessControlSigningBehaviorsAlways),
+				SigningProtocol:               aws.String(awscloudfront.OriginAccessControlSigningProtocolsSigv4),
+			},
+		},
+	}
+
+	got, err := NewAOCRepository(s.client, s.lister).Sync(AOC{
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	})
+
+	s.NoError(err)
+	s.Equal(AOC{
+		ID:                            "id",
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	}, got)
+}
+
+func (s *aocRepositorySuite) TestSync_AOCWillBeUpdatedAndShouldReturnNoError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+	s.lister.expectedPages = []*awscloudfront.ListOriginAccessControlsOutput{
+		{
+			OriginAccessControlList: &awscloudfront.OriginAccessControlList{Items: []*awscloudfront.OriginAccessControlSummary{
+				{
+					Id:   aws.String("id"),
+					Name: aws.String("name"), // we just want this to match the name, the rest isn't important
+				},
+			}},
+		},
+	}
+
+	s.client.On("UpdateOriginAccessControl", mock.Anything).
+		Return(noError)
+
+	s.client.ExpectedUpdateOriginAccessControlOutput = &awscloudfront.UpdateOriginAccessControlOutput{
+		OriginAccessControl: &awscloudfront.OriginAccessControl{
+			Id: aws.String("id"),
+			OriginAccessControlConfig: &awscloudfront.OriginAccessControlConfig{
+				Name:                          aws.String("name"),
+				OriginAccessControlOriginType: aws.String(awscloudfront.OriginAccessControlOriginTypesS3),
+				SigningBehavior:               aws.String(awscloudfront.OriginAccessControlSigningBehaviorsAlways),
+				SigningProtocol:               aws.String(awscloudfront.OriginAccessControlSigningProtocolsSigv4),
+			},
+		},
+	}
+
+	got, err := NewAOCRepository(s.client, s.lister).Sync(AOC{
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	})
+
+	s.NoError(err)
+	s.Equal(AOC{
+		ID:                            "id",
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	}, got)
+}
+func (s *aocRepositorySuite) TestSync_AOCFailsToBeFetchedAndShouldReturnError() {
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(errors.New("some error"))
+
+	got, err := NewAOCRepository(s.client, s.lister).Sync(AOC{
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	})
+
+	s.Error(err)
+	s.Empty(got)
+}
+
+func (s *aocRepositorySuite) TestSync_AOCFailsToBeCreatedAndShouldReturnError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+	s.client.On("CreateOriginAccessControl", mock.Anything).
+		Return(errors.New("some error"))
+
+	got, err := NewAOCRepository(s.client, s.lister).Sync(AOC{
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	})
+
+	s.Error(err)
+	s.Empty(got)
+}
+
+func (s *aocRepositorySuite) TestSync_AOCFailsToBeUpdatedAndShouldReturnError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+	s.lister.expectedPages = []*awscloudfront.ListOriginAccessControlsOutput{
+		{
+			OriginAccessControlList: &awscloudfront.OriginAccessControlList{Items: []*awscloudfront.OriginAccessControlSummary{
+				{
+					Id:   aws.String("id"),
+					Name: aws.String("name"), // we just want this to match the name, the rest isn't important
+				},
+			}},
+		},
+	}
+
+	s.client.On("UpdateOriginAccessControl", mock.Anything).
+		Return(errors.New("some error"))
+
+	got, err := NewAOCRepository(s.client, s.lister).Sync(AOC{
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	})
+
+	s.Error(err)
+	s.Empty(got)
+}
+
+func (s *aocRepositorySuite) TestDelete_AOCWillBeDeletedAndShouldReturnNoError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+	s.lister.expectedPages = []*awscloudfront.ListOriginAccessControlsOutput{
+		{
+			OriginAccessControlList: &awscloudfront.OriginAccessControlList{Items: []*awscloudfront.OriginAccessControlSummary{
+				{
+					Id:                            aws.String("id"),
+					Name:                          aws.String("name"),
+					OriginAccessControlOriginType: aws.String("s3"),
+					SigningBehavior:               aws.String("always"),
+					SigningProtocol:               aws.String("sigv4"),
+				},
+			}},
+		},
+	}
+
+	s.client.On("DeleteOriginAccessControl", mock.Anything).
+		Return(noError)
+
+	got, err := NewAOCRepository(s.client, s.lister).Delete(AOC{
+		Name:       "name",
+		OriginName: "originName",
+	})
+
+	s.NoError(err)
+	s.Equal(AOC{
+		ID:                            "id",
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	}, got)
+}
+
+func (s *aocRepositorySuite) TestDelete_AOCDoesNotExistAndShouldReturnNoError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+
+	got, err := NewAOCRepository(s.client, s.lister).Delete(AOC{
+		Name:       "name",
+		OriginName: "originName",
+	})
+
+	s.NoError(err)
+	s.Equal(AOC{}, got)
+}
+
+func (s *aocRepositorySuite) TestDelete_AOCWasDeletedExternallyAfterFetchingAndShouldReturnNoError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+	s.lister.expectedPages = []*awscloudfront.ListOriginAccessControlsOutput{
+		{
+			OriginAccessControlList: &awscloudfront.OriginAccessControlList{Items: []*awscloudfront.OriginAccessControlSummary{
+				{
+					Id:                            aws.String("id"),
+					Name:                          aws.String("name"),
+					OriginAccessControlOriginType: aws.String("s3"),
+					SigningBehavior:               aws.String("always"),
+					SigningProtocol:               aws.String("sigv4"),
+				},
+			}},
+		},
+	}
+
+	s.client.On("DeleteOriginAccessControl", mock.Anything).
+		Return(awserr.New(awscloudfront.ErrCodeNoSuchOriginAccessControl, "msg", nil))
+
+	got, err := NewAOCRepository(s.client, s.lister).Delete(AOC{
+		Name:       "name",
+		OriginName: "originName",
+	})
+
+	s.NoError(err)
+	s.Equal(AOC{
+		ID:                            "id",
+		Name:                          "name",
+		OriginName:                    "originName",
+		OriginAccessControlOriginType: "s3",
+		SigningBehavior:               "always",
+		SigningProtocol:               "sigv4",
+	}, got)
+}
+
+func (s *aocRepositorySuite) TestDelete_FailedToGetAOCAndShouldReturnError() {
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(errors.New("some error"))
+	got, err := NewAOCRepository(s.client, s.lister).Delete(AOC{
+		Name:       "name",
+		OriginName: "originName",
+	})
+
+	s.Error(err)
+	s.Empty(got)
+}
+
+func (s *aocRepositorySuite) TestDelete_FailedToDeleteAndShouldReturnError() {
+	var noError error
+	s.lister.On("ListOriginAccessControlsPages", mock.Anything, mock.Anything).
+		Return(noError)
+	s.lister.expectedPages = []*awscloudfront.ListOriginAccessControlsOutput{
+		{
+			OriginAccessControlList: &awscloudfront.OriginAccessControlList{Items: []*awscloudfront.OriginAccessControlSummary{
+				{
+					Id:                            aws.String("id"),
+					Name:                          aws.String("name"),
+					OriginAccessControlOriginType: aws.String("s3"),
+					SigningBehavior:               aws.String("always"),
+					SigningProtocol:               aws.String("sigv4"),
+				},
+			}},
+		},
+	}
+
+	s.client.On("DeleteOriginAccessControl", mock.Anything).
+		Return(errors.New("some error"))
+
+	got, err := NewAOCRepository(s.client, s.lister).Delete(AOC{
+		Name:       "name",
+		OriginName: "originName",
+	})
+
+	s.Error(err)
+	s.Empty(got)
+}

--- a/internal/test/cloudfront_api_mock.go
+++ b/internal/test/cloudfront_api_mock.go
@@ -34,6 +34,9 @@ type MockCloudFrontAPI struct {
 	ExpectedCreateDistributionWithTagsOutput *cloudfront.CreateDistributionWithTagsOutput
 	ExpectedTagResourceOutput                *cloudfront.TagResourceOutput
 	ExpectedGetDistributionOutput            *cloudfront.GetDistributionOutput
+	ExpectedCreateOriginAccessControlOutput  *cloudfront.CreateOriginAccessControlOutput
+	ExpectedUpdateOriginAccessControlOutput  *cloudfront.UpdateOriginAccessControlOutput
+	ExpectedDeleteOriginAccessControlOutput  *cloudfront.DeleteOriginAccessControlOutput
 }
 
 func (c *MockCloudFrontAPI) GetDistributionConfig(in *cloudfront.GetDistributionConfigInput) (*cloudfront.GetDistributionConfigOutput, error) {
@@ -63,4 +66,19 @@ func (c *MockCloudFrontAPI) TagResource(in *cloudfront.TagResourceInput) (*cloud
 func (c *MockCloudFrontAPI) DeleteDistribution(in *cloudfront.DeleteDistributionInput) (*cloudfront.DeleteDistributionOutput, error) {
 	args := c.Called(in)
 	return nil, args.Error(0)
+}
+
+func (c *MockCloudFrontAPI) CreateOriginAccessControl(in *cloudfront.CreateOriginAccessControlInput) (*cloudfront.CreateOriginAccessControlOutput, error) {
+	args := c.Called(in)
+	return c.ExpectedCreateOriginAccessControlOutput, args.Error(0)
+}
+
+func (c *MockCloudFrontAPI) UpdateOriginAccessControl(in *cloudfront.UpdateOriginAccessControlInput) (*cloudfront.UpdateOriginAccessControlOutput, error) {
+	args := c.Called(in)
+	return c.ExpectedUpdateOriginAccessControlOutput, args.Error(0)
+}
+
+func (c *MockCloudFrontAPI) DeleteOriginAccessControl(in *cloudfront.DeleteOriginAccessControlInput) (*cloudfront.DeleteOriginAccessControlOutput, error) {
+	args := c.Called(in)
+	return c.ExpectedDeleteOriginAccessControlOutput, args.Error(0)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
TSIA

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
Necessary so that we can eventually support direct access to private S3 buckets that are not set up with static website hosting as origin.

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->
Automated tests.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [ ] I have updated the documentation accordingly.
