### PR TITLE
[PE1-1251] Add logic to use S3OriginConfig instead of CustomOriginConfig if origin is a bucket

### DIFF
--- a/internal/cloudfront/aws_models.go
+++ b/internal/cloudfront/aws_models.go
@@ -138,10 +138,7 @@ func newAWSOrigin(o Origin) *cloudfront.Origin {
 				Quantity: aws.Int64(int64(len(SSLProtocols))),
 			},
 		}
-		originAccessControlID = nil
-		s3OriginConfig = nil
 	} else {
-		customOriginConfig = nil
 		originAccessControlID = &o.OAC.ID
 		s3OriginConfig = &cloudfront.S3OriginConfig{
 			OriginAccessIdentity: aws.String(""),

--- a/internal/cloudfront/aws_models.go
+++ b/internal/cloudfront/aws_models.go
@@ -126,7 +126,7 @@ func newAWSOrigin(o Origin) *cloudfront.Origin {
 	var originAccessControlID *string
 	var s3OriginConfig *cloudfront.S3OriginConfig
 
-	if o.Type == OriginTypePublic {
+	if o.Access == OriginAccessPublic {
 		customOriginConfig = &cloudfront.CustomOriginConfig{
 			HTTPPort:               aws.Int64(80),
 			HTTPSPort:              aws.Int64(443),

--- a/internal/cloudfront/aws_models.go
+++ b/internal/cloudfront/aws_models.go
@@ -122,9 +122,12 @@ func newAWSOrigin(o Origin) *cloudfront.Origin {
 		aws.String(originSSLProtocolTLSv12),
 	}
 
-	return &cloudfront.Origin{
-		CustomHeaders: &cloudfront.CustomHeaders{Quantity: aws.Int64(0)},
-		CustomOriginConfig: &cloudfront.CustomOriginConfig{
+	var customOriginConfig *cloudfront.CustomOriginConfig
+	var originAccessControlID *string
+	var s3OriginConfig *cloudfront.S3OriginConfig
+
+	if o.Type == OriginTypePublic {
+		customOriginConfig = &cloudfront.CustomOriginConfig{
 			HTTPPort:               aws.Int64(80),
 			HTTPSPort:              aws.Int64(443),
 			OriginKeepaliveTimeout: aws.Int64(5),
@@ -134,10 +137,25 @@ func newAWSOrigin(o Origin) *cloudfront.Origin {
 				Items:    SSLProtocols,
 				Quantity: aws.Int64(int64(len(SSLProtocols))),
 			},
-		},
-		DomainName: aws.String(o.Host),
-		Id:         aws.String(o.Host),
-		OriginPath: aws.String(""),
+		}
+		originAccessControlID = nil
+		s3OriginConfig = nil
+	} else {
+		customOriginConfig = nil
+		originAccessControlID = &o.OAC.ID
+		s3OriginConfig = &cloudfront.S3OriginConfig{
+			OriginAccessIdentity: aws.String(""),
+		}
+	}
+
+	return &cloudfront.Origin{
+		CustomHeaders:         &cloudfront.CustomHeaders{Quantity: aws.Int64(0)},
+		CustomOriginConfig:    customOriginConfig,
+		DomainName:            aws.String(o.Host),
+		Id:                    aws.String(o.Host),
+		OriginAccessControlId: originAccessControlID,
+		OriginPath:            aws.String(""),
+		S3OriginConfig:        s3OriginConfig,
 	}
 }
 

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -51,7 +51,7 @@ type Origin struct {
 
 // HasEqualParameters returns whether both Origins have the same parameters. It ignores differences in Behaviors
 func (o Origin) HasEqualParameters(o2 Origin) bool {
-	return o.Host == o2.Host && o.ResponseTimeout == o2.ResponseTimeout
+	return o.Host == o2.Host && o.ResponseTimeout == o2.ResponseTimeout && o.Type == o2.Type && o.OAC == o2.OAC
 }
 
 // Behavior represents a CloudFront Cache Behavior
@@ -83,9 +83,9 @@ type OriginBuilder struct {
 // NewOriginBuilder returns an OriginBuilder for a given host
 func NewOriginBuilder(distributionName, host, accessType string) OriginBuilder {
 	return OriginBuilder{
+		distributionName: distributionName,
 		host:             host,
 		respTimeout:      defaultResponseTimeout,
-		distributionName: distributionName,
 		requestPolicy:    defaultRequestPolicyForType(accessType),
 		cachePolicy:      cachingDisabledPolicyID,
 		paths:            strhelper.NewSet(),

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -186,7 +186,9 @@ func (b OriginBuilder) addCachePolicyBehaviors(origin Origin) Origin {
 }
 
 func (b OriginBuilder) addOriginAccessConfiguration(origin Origin) Origin {
-	if b.accessType != OriginAccessBucket {
+	origin.Access = b.accessType
+
+	if origin.Access != OriginAccessBucket {
 		return origin
 	}
 

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -51,7 +51,7 @@ type Origin struct {
 
 // HasEqualParameters returns whether both Origins have the same parameters. It ignores differences in Behaviors
 func (o Origin) HasEqualParameters(o2 Origin) bool {
-	return o.Host == o2.Host && o.ResponseTimeout == o2.ResponseTimeout && o.Type == o2.Type && o.OAC == o2.OAC
+	return o.Host == o2.Host && o.ResponseTimeout == o2.ResponseTimeout && o.Access == o2.Access && o.OAC == o2.OAC
 }
 
 // Behavior represents a CloudFront Cache Behavior
@@ -152,6 +152,8 @@ func (b OriginBuilder) Build() Origin {
 	origin = b.addCachePolicyBehaviors(origin)
 	origin = b.addRequestPolicyToBehaviors(origin)
 
+	origin.Access = b.accessType
+
 	origin = b.addOriginAccessConfiguration(origin)
 
 	return origin
@@ -186,8 +188,6 @@ func (b OriginBuilder) addCachePolicyBehaviors(origin Origin) Origin {
 }
 
 func (b OriginBuilder) addOriginAccessConfiguration(origin Origin) Origin {
-	origin.Access = b.accessType
-
 	if origin.Access != OriginAccessBucket {
 		return origin
 	}

--- a/internal/cloudfront/origin_test.go
+++ b/internal/cloudfront/origin_test.go
@@ -37,6 +37,7 @@ type OriginTestSuite struct {
 func (s *OriginTestSuite) TestNewOriginBuilder_DefaultsForPublicOrigin() {
 	o := NewOriginBuilder("dist", "origin", "Public").WithBehavior("/*").Build()
 
+	s.Equal("Public", o.Type)
 	s.Equal(int64(30), o.ResponseTimeout)
 	s.Equal(allViewerOriginRequestPolicyID, o.Behaviors[0].RequestPolicy)
 }
@@ -113,10 +114,11 @@ func (s *OriginTestSuite) TestNewOriginBuilder_WithRequestPolicy() {
 	s.Equal("some-policy", o.Behaviors[1].RequestPolicy)
 }
 
-func (s *OriginTestSuite) TestNewOriginBuilder_WithOriginAccessIdentity() {
+func (s *OriginTestSuite) TestNewOriginBuilder_WithBucketType() {
 	o := NewOriginBuilder("dist", "origin", "Bucket").
 		Build()
 	s.Equal("origin", o.Host)
+	s.Equal("Bucket", o.Type)
 	s.Equal("dist-origin", o.OAC.Name)
 	s.Equal("origin", o.OAC.OriginName)
 	s.Equal("s3", o.OAC.OriginAccessControlOriginType)

--- a/internal/cloudfront/origin_test.go
+++ b/internal/cloudfront/origin_test.go
@@ -112,3 +112,28 @@ func (s *OriginTestSuite) TestNewOriginBuilder_WithRequestPolicy() {
 	s.Equal("some-policy", o.Behaviors[0].RequestPolicy)
 	s.Equal("some-policy", o.Behaviors[1].RequestPolicy)
 }
+
+func (s *OriginTestSuite) TestNewOriginBuilder_WithOriginAccessIdentity() {
+	o := NewOriginBuilder("dist", "origin", "Bucket").
+		Build()
+	s.Equal("origin", o.Host)
+	s.Equal("dist-origin", o.OAC.Name)
+	s.Equal("origin", o.OAC.OriginName)
+	s.Equal("s3", o.OAC.OriginAccessControlOriginType)
+}
+
+func (s *OriginTestSuite) TestNewOriginBuilder_TestHasDifferentParameters() {
+	o := NewOriginBuilder("dist", "origin", "Bucket").
+		Build()
+	o1 := NewOriginBuilder("foo", "origin", "Bucket").
+		Build()
+	o2 := NewOriginBuilder("dist", "bar", "Bucket").
+		Build()
+	o3 := NewOriginBuilder("dist", "origin", "Public").
+		Build()
+
+	s.False(o.HasEqualParameters(o1))
+	s.False(o.HasEqualParameters(o2))
+	s.False(o.HasEqualParameters(o3))
+	s.True(o.HasEqualParameters(o))
+}

--- a/internal/cloudfront/origin_test.go
+++ b/internal/cloudfront/origin_test.go
@@ -37,7 +37,7 @@ type OriginTestSuite struct {
 func (s *OriginTestSuite) TestNewOriginBuilder_DefaultsForPublicOrigin() {
 	o := NewOriginBuilder("dist", "origin", "Public").WithBehavior("/*").Build()
 
-	s.Equal("Public", o.Type)
+	s.Equal("Public", o.Access)
 	s.Equal(int64(30), o.ResponseTimeout)
 	s.Equal(allViewerOriginRequestPolicyID, o.Behaviors[0].RequestPolicy)
 }
@@ -118,7 +118,7 @@ func (s *OriginTestSuite) TestNewOriginBuilder_WithBucketType() {
 	o := NewOriginBuilder("dist", "origin", "Bucket").
 		Build()
 	s.Equal("origin", o.Host)
-	s.Equal("Bucket", o.Type)
+	s.Equal("Bucket", o.Access)
 	s.Equal("dist-origin", o.OAC.Name)
 	s.Equal("origin", o.OAC.OriginName)
 	s.Equal("s3", o.OAC.OriginAccessControlOriginType)

--- a/internal/cloudfront/repository_test.go
+++ b/internal/cloudfront/repository_test.go
@@ -871,7 +871,7 @@ func (s *DistributionRepositoryTestSuite) TestCreate_SuccessWithBucketOrigin() {
 
 	repo := NewDistributionRepository(awsClient, &test.MockResourceTaggingAPI{}, testCallerRefFn, time.Minute)
 	dist, err := repo.Create(distribution)
-	s.Equal(dist.CustomOrigins[0].Type, "Bucket")
+	s.Equal(dist.CustomOrigins[0].Access, "Bucket")
 	s.Equal(dist.CustomOrigins[0].OAC.Name, "dist-origin")
 	s.Equal(dist.CustomOrigins[0].OAC.OriginName, "origin")
 	s.Equal(dist.CustomOrigins[0].OAC.OriginAccessControlOriginType, "s3")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
- Move OAC struct to separate file
- Add type to Origin (Public or Bucket)
- Rename stuff wrongly created as `aoc` to `oac`
- Conditional configuration of s3 origin config in AWS models
- Add logic to handle s3 origin types

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
https://gympass.atlassian.net/browse/PE1-1251

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->
Automated tests

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [ ] I have updated the documentation accordingly.
