### PR TITLE
[PE1-1292] manage OACs in distribution repository

### DIFF
--- a/internal/cloudfront/distribution.go
+++ b/internal/cloudfront/distribution.go
@@ -78,6 +78,25 @@ func (d Distribution) IsEmpty() bool {
 	return len(d.CustomOrigins) == 0
 }
 
+func (d Distribution) OACs() []OAC {
+	var result []OAC
+	for _, o := range d.CustomOrigins {
+		if o.isBucketBased() {
+			result = append(result, o.OAC)
+		}
+	}
+	return result
+}
+
+func (d Distribution) HasOrigin(originHost string) bool {
+	for _, o := range d.CustomOrigins {
+		if o.Host == originHost {
+			return true
+		}
+	}
+	return false
+}
+
 // DistributionBuilder allows the construction of a Distribution
 type DistributionBuilder struct {
 	id                  string

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -54,6 +54,10 @@ func (o Origin) HasEqualParameters(o2 Origin) bool {
 	return o.Host == o2.Host && o.ResponseTimeout == o2.ResponseTimeout && o.Access == o2.Access && o.OAC == o2.OAC
 }
 
+func (o Origin) isBucketBased() bool {
+	return o.Access == OriginAccessBucket
+}
+
 // Behavior represents a CloudFront Cache Behavior
 type Behavior struct {
 	// PathPattern is the path pattern used when configuring the Behavior

--- a/internal/strhelper/strings.go
+++ b/internal/strhelper/strings.go
@@ -80,3 +80,11 @@ func MergeMapString(m1, m2 map[string]string) map[string]string {
 	}
 	return nm
 }
+
+// IsEmptyOrNil returns whether str is empty or nil
+func IsEmptyOrNil(str *string) bool {
+	if str == nil {
+		return true
+	}
+	return *str == ""
+}

--- a/main.go
+++ b/main.go
@@ -130,12 +130,20 @@ func leaderElectionID(cdnClass string) string {
 func mustSetupControllers(mgr manager.Manager, cfg config.Config) {
 	s := session.Must(session.NewSession())
 
+	cfClient := awscloudfront.New(s)
+
 	callerRefFn := func() string { return time.Now().String() }
 	waitTimeout := time.Minute * 10
 	cfService := &cloudfront.Service{
-		Client:    mgr.GetClient(),
-		Recorder:  mgr.GetEventRecorderFor("cdn-origin-controller"),
-		DistRepo:  cloudfront.NewDistributionRepository(awscloudfront.New(s), resourcegroupstaggingapi.New(s), callerRefFn, waitTimeout),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("cdn-origin-controller"),
+		DistRepo: cloudfront.NewDistributionRepository(
+			cfClient,
+			resourcegroupstaggingapi.New(s),
+			cloudfront.NewOACRepository(cfClient, cloudfront.NewOACLister(cfClient)),
+			callerRefFn,
+			waitTimeout,
+		),
 		AliasRepo: route53.NewAliasRepository(awsroute53.New(s), cfg),
 		Config:    cfg,
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->

Update the Distribution repository to delegate syncing and deleting OACs to the OAC repo.

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
This is needed in order to support private S3 buckets as origins via OAC (Origin Access Control).

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->
Automated tests.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [ ] I have updated the documentation accordingly.
