### PR TITLE
fix: removes unused cdn_class var env

### DIFF
--- a/controllers/predicate_test.go
+++ b/controllers/predicate_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/Gympass/cdn-origin-controller/internal/config"
 	"github.com/Gympass/cdn-origin-controller/internal/k8s"
 )
 
@@ -68,10 +67,6 @@ var (
 		return i
 	}()
 )
-
-func (s *PredicateSuite) SetupTest() {
-	viper.Set(config.CDNClassKey, "default")
-}
 
 func (s *PredicateSuite) TearDownTest() {
 	viper.Reset()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,8 +27,6 @@ import (
 )
 
 const (
-	// CDNClassKey is the env var key that controls class
-	CDNClassKey                                   = "cdn_class"
 	logLevelKey                                   = "log_level"
 	devModeKey                                    = "dev_mode"
 	enableDeletionKey                             = "enable_deletion"
@@ -54,7 +52,6 @@ func init() {
 	viper.SetDefault(logLevelKey, "info")
 	viper.SetDefault(devModeKey, "false")
 	viper.SetDefault(enableDeletionKey, "false")
-	viper.SetDefault(CDNClassKey, "default")
 	viper.SetDefault(cfDefaultOriginDomainKey, "")
 	viper.SetDefault(cfPriceClassKey, awscloudfront.PriceClassPriceClassAll)
 	viper.SetDefault(cfWafArnKey, "")
@@ -92,8 +89,6 @@ type Config struct {
 	DeletionEnabled bool
 	// DefaultOriginDomain represents a valid domain to define in default origin.
 	DefaultOriginDomain string
-	// CDNClass represents the set of resources managed by this deployment of the controller
-	CDNClass string
 	// CloudFrontPriceClass determines how many edge locations CloudFront will use for your distribution.
 	// ref: https://docs.aws.amazon.com/sdk-for-go/api/service/cloudfront/
 	CloudFrontPriceClass string
@@ -157,11 +152,6 @@ func Parse() Config {
 		CloudFrontDefaultPublicOriginAccessRequestPolicyID: viper.GetString(cfDefaultPublicOriginAccessRequestPolicyIDKey),
 		CloudFrontDefaultBucketOriginAccessRequestPolicyID: viper.GetString(cfDefaultBucketOriginAccessRequestPolicyIDKey),
 	}
-}
-
-// CDNClass returns the configured CDN class
-func CDNClass() string {
-	return viper.GetString(CDNClassKey)
 }
 
 func extractTags(customTags string) map[string]string {

--- a/main.go
+++ b/main.go
@@ -68,6 +68,10 @@ func init() {
 	_ = godotenv.Load()
 }
 
+const (
+	leaderElectionID = "cdn-origin.gympass.com"
+)
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -96,7 +100,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       leaderElectionID(cfg.CDNClass),
+		LeaderElectionID:       leaderElectionID,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -121,10 +125,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func leaderElectionID(cdnClass string) string {
-	return fmt.Sprintf("%s.cdn-origin.gympass.com", cdnClass)
 }
 
 func mustSetupControllers(mgr manager.Manager, cfg config.Config) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
Removing the implementation of cdn_class var env, this information will be available through the CDNClass resource.

## Motivation and Context
Hot fix.

## How has this been tested?
Manually

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [x] I have updated the documentation accordingly.
