### PR TITLE
Improve error from bad existing records

### DIFF
--- a/charts/cdn-origin-controller/Chart.yaml
+++ b/charts/cdn-origin-controller/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: The cdn-origin-controller Helm Chart
 name: cdn-origin-controller
-version: v0.2.2
+version: v0.2.3

--- a/charts/cdn-origin-controller/templates/cdnclass.yaml
+++ b/charts/cdn-origin-controller/templates/cdnclass.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   certificateArn: {{ .certificateArn }}
   hostedZoneID: {{ .hostedZoneID }}
+  createAlias: {{ .createAlias }}
+  txtOwnerValue: {{ .txtOwnerValue }}
 {{- end }}
 {{ end }}
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
Checks if existing DNS records have a valid routing policy.

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
Prevents cryptic errors such as:
```
1 error occurred:
	* InvalidChangeBatch: [RRSet with DNS name foo.bar., type A cannot be created as other RRSets exist with the same name and type., RRSet with DNS name foo.bar., type AAAA cannot be created as other RRSets exist with the same name and type., RRSet with DNS name foo.bar., type TXT cannot be created as other RRSets exist with the same name and type.]
	status code: 400, request id: 000000000
```

These happen when a record we're upserting already exists (which is usually ok) but have a different routing policy than the one we're upserting (which is not ok).

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->

Manually validated in environment where this was spotted.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have implemented automated tests for the changes.
- [ ] I have updated the documentation accordingly.
