### PR TITLE
[PE1-1796] feat: discover ACM certificates automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ The controller has several [infrastructure configurations](#configuration). In o
 
 | Parameter      | Required | Description                                                                                                                                                      |   |   |
 |----------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|---|
-| certificateArn | yes      | The ARN of ACM certificate which should be used by the distributions.                                                                                            |   |   |
 | hostedZoneID   | yes      | The ID of the Route53 zone where the aliases should be created in.                                                                                               |   |   |
 | createAlias    | yes      | Whether the controller should create DNS records for a distribution's alternate domain names.                                                                    |   |   |
 | txtOwnerValue  | yes      | The controller creates TXT records for managing aliases. In it, a value is written to bind that given record to a particular instance of the controller running. |   |   |
 
-For example, imagine you need some of your CloudFront distributions to be in the `foo.com` zone and the others on the `bar.com` zone. In order to do that you need create both `CDNClass` kinds and set different values for the `hostedZoneID`, `certificateArn`, `createAlias` and `txtOwnerValue` parameters.
+For example, imagine you need some of your CloudFront distributions to be in the `foo.com` zone and the others on the `bar.com` zone. In order to do that you need create both `CDNClass` kinds and set different values for the `hostedZoneID`, `createAlias` and `txtOwnerValue` parameters.
 
 For this example, for the first kind we should have:
 
@@ -66,7 +65,6 @@ kind: CDNClass
 metadata:
   name: foo-com
 spec:
-  certificateArn: "<Certificate ARN from given hosted zone>"
   hostedZoneID: "<foo-com hosted zone ID>"
   createAlias: true
   txtOwnerValue: "<foo-owner value>"
@@ -80,7 +78,6 @@ kind: CDNClass
 metadata:
   name: bar-com
 spec:
-  certificateArn: "<Certificate ARN from given hosted zone>"
   hostedZoneID: "<bar-com hosted zone ID>"
   createAlias: true
   txtOwnerValue: "<bar-owner value>"
@@ -99,6 +96,11 @@ While Ingresses that serve as origins for CloudFronts at the `bar.com` zone shou
 ``` yaml
 cdn-origin-controller.gympass.com/cdn.class: bar-com
 ```
+### TLS Certificate configuration
+
+TLS will automatically be enabled if the `CF_SECURITY_POLICY` env var is set, and is disabled by default.
+
+The controller will automatically search for TLS certificates in [AWS ACM](https://aws.amazon.com/certificate-manager/). If it finds a certificate matching any of the Distribution's alternate domain names, it will bind that certificate to the Distribution.
 
 ## Behavior ordering
 

--- a/api/v1alpha1/cdnclass_types.go
+++ b/api/v1alpha1/cdnclass_types.go
@@ -28,8 +28,7 @@ import (
 
 // CDNClassSpec defines the desired state of CDNClass
 type CDNClassSpec struct {
-	// CertificateArn represents a valid Certificate ARN for a domain name
-	// +kubebuilder:validation:Required
+	// CertificateArn is deprecated, certs are now automatically discovered and this field is ignored
 	CertificateArn string `json:"certificateArn"`
 	// HostedZoneID represents a valid hosted zone ID for a domain name
 	// +kubebuilder:validation:Required

--- a/charts/cdn-origin-controller/templates/crds/cdn.gympass.com_cdnclasses.yaml
+++ b/charts/cdn-origin-controller/templates/crds/cdn.gympass.com_cdnclasses.yaml
@@ -35,8 +35,8 @@ spec:
             description: CDNClassSpec defines the desired state of CDNClass
             properties:
               certificateArn:
-                description: CertificateArn represents a valid Certificate ARN for
-                  a domain name
+                description: CertificateArn is deprecated, certs are now automatically
+                  discovered and this field is ignored
                 type: string
               createAlias:
                 description: CreateAlias determine if should create an DNS alias for

--- a/config/crd/bases/cdn.gympass.com_cdnclasses.yaml
+++ b/config/crd/bases/cdn.gympass.com_cdnclasses.yaml
@@ -35,8 +35,8 @@ spec:
             description: CDNClassSpec defines the desired state of CDNClass
             properties:
               certificateArn:
-                description: CertificateArn represents a valid Certificate ARN for
-                  a domain name
+                description: CertificateArn is deprecated, certs are now automatically
+                  discovered and this field is ignored
                 type: string
               createAlias:
                 description: CreateAlias determine if should create an DNS alias for

--- a/config/samples/cdn_v1alpha1_cdnclass.yaml
+++ b/config/samples/cdn_v1alpha1_cdnclass.yaml
@@ -3,7 +3,6 @@ kind: CDNClass
 metadata:
   name: cdnclass-sample
 spec:
-  certificateArn: arn:aws:acm:us-east-1:215023620964:certificate/928e8e0d-eb37-4c47-b324-159cdbffbef2
-  hostedZoneID: Z02652453DOG4JF0CLCC7
+  hostedZoneID: 000000000000000000000
   createAlias: true
   txtOwnerValue: "owner value"

--- a/config/samples/cdn_v1alpha1_eu_cdnclass.yaml
+++ b/config/samples/cdn_v1alpha1_eu_cdnclass.yaml
@@ -1,7 +1,0 @@
-apiVersion: cdn.gympass.com/v1alpha1
-kind: CDNClass
-metadata:
-  name: pe-dev-eu-gympass-cloud
-spec:
-  certificateArn: arn:aws:acm:us-east-1:215023620964:certificate/928e8e0d-eb37-4c47-b324-159cdbffbef2
-  hostedZoneID: Z0592540H7Z9HQ6NEBH2

--- a/internal/certificate/certificate.go
+++ b/internal/certificate/certificate.go
@@ -17,40 +17,35 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-package k8s
+package certificate
 
-import (
-	"context"
-
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/Gympass/cdn-origin-controller/api/v1alpha1"
-)
-
-type CDNClassFetcher interface {
-	FetchByName(ctx context.Context, name string) (CDNClass, error)
-}
-
-type cdnClassFetcher struct {
-	k8sClient client.Client
-}
-
-func NewCDNClassFetcher(client client.Client) CDNClassFetcher {
-	return cdnClassFetcher{k8sClient: client}
-}
-
-func (c cdnClassFetcher) FetchByName(ctx context.Context, name string) (CDNClass, error) {
-	k8sClass := &v1alpha1.CDNClass{}
-	err := c.k8sClient.Get(ctx, types.NamespacedName{Name: name}, k8sClass)
-
-	if err != nil {
-		return CDNClass{}, err
+// New creates a Certificate
+func New(arn, domainName string, alternativeNames []string /*, renewalEligibility string*/) Certificate {
+	return Certificate{
+		arn:              arn,
+		domainName:       domainName,
+		alternativeNames: alternativeNames,
 	}
+}
 
-	return CDNClass{
-		HostedZoneID:  k8sClass.Spec.HostedZoneID,
-		CreateAlias:   k8sClass.Spec.CreateAlias,
-		TXTOwnerValue: k8sClass.Spec.TXTOwnerValue,
-	}, err
+// Certificate represents a basic certificate
+type Certificate struct {
+	arn              string
+	domainName       string
+	alternativeNames []string
+}
+
+// DomainName returns the main certificate domain name
+func (c Certificate) DomainName() string {
+	return c.domainName
+}
+
+// AlternativeNames returns a list of certificate subject alternative names
+func (c Certificate) AlternativeNames() []string {
+	return c.alternativeNames
+}
+
+// ARN returns the certificate identifier
+func (c Certificate) ARN() string {
+	return c.arn
 }

--- a/internal/certificate/repository.go
+++ b/internal/certificate/repository.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package certificate
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/acm/acmiface"
+)
+
+var (
+	errFindCert = errors.New("finding certificate")
+)
+
+// CertFilter type represents a certificate filter interface
+type CertFilter func(c Certificate) bool
+
+// Repository provides methods for manipulating Custom domain names on AWS
+type Repository interface {
+	FindByFilter(CertFilter) ([]Certificate, error)
+}
+
+type acmCertRepository struct {
+	client acmiface.ACMAPI
+}
+
+// NewRepository creates a new Repository
+func NewRepository(c acmiface.ACMAPI) Repository {
+	return acmCertRepository{client: c}
+}
+
+// FindByFilter find a certificate given a filter
+func (r acmCertRepository) FindByFilter(filter CertFilter) ([]Certificate, error) {
+
+	input := &acm.ListCertificatesInput{
+		CertificateStatuses: aws.StringSlice([]string{acm.CertificateStatusIssued}),
+	}
+
+	var certs []Certificate
+	var certDiscoveryErr error
+
+	err := r.client.ListCertificatesPages(input, func(output *acm.ListCertificatesOutput, _ bool) bool {
+		for _, acmCertSummary := range output.CertificateSummaryList {
+			acmCert, err := r.client.DescribeCertificate(&acm.DescribeCertificateInput{
+				CertificateArn: acmCertSummary.CertificateArn,
+			})
+
+			if err != nil {
+				certDiscoveryErr = fmt.Errorf("describing certificate (ARN: %s): %v", *acmCertSummary.CertificateArn, err)
+				return false
+			}
+
+			certDetails := acmCert.Certificate
+			dnCert := New(*certDetails.CertificateArn,
+				*certDetails.DomainName,
+				aws.StringValueSlice(acmCert.Certificate.SubjectAlternativeNames),
+			)
+			if filter(dnCert) {
+				certs = append(certs, dnCert)
+			}
+		}
+		return true
+	})
+
+	if certDiscoveryErr != nil {
+		err = certDiscoveryErr
+	}
+	if err != nil {
+		return []Certificate{}, fmt.Errorf("%w: %v", errFindCert, err)
+	}
+
+	return certs, nil
+}

--- a/internal/certificate/service.go
+++ b/internal/certificate/service.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package certificate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	// ErrNoMatchingCert any matching certificate error
+	ErrNoMatchingCert = errors.New("could not find any matching certificate")
+)
+
+// Service handle the certificate actions as discovery
+type Service interface {
+	DiscoverByHost(string) (Certificate, error)
+}
+
+// NewService creates a new Certificate Service
+func NewService(c Repository) Service {
+	return acmCertService{repo: c}
+}
+
+type acmCertService struct {
+	repo Repository
+}
+
+// DiscoverByHost tries to discover a certificate given a host
+func (a acmCertService) DiscoverByHost(host string) (Certificate, error) {
+
+	certs, err := a.repo.FindByFilter(matchingDomainFilter(host))
+
+	if err != nil {
+		return Certificate{}, fmt.Errorf("discovery certificate: %v", err)
+	}
+
+	if len(certs) == 0 {
+		return Certificate{}, ErrNoMatchingCert
+	}
+
+	return certs[0], nil
+}
+
+func matchingDomainFilter(host string) CertFilter {
+	return func(c Certificate) bool {
+		if host == c.DomainName() {
+			return true
+		}
+
+		for _, alterName := range c.AlternativeNames() {
+			hs := strings.Split(host, ".")
+			hostDomain := strings.Join(hs[1:], ".")
+
+			if strings.HasPrefix(alterName, "*.") {
+				alterName = strings.ReplaceAll(alterName, "*.", "")
+			}
+
+			if alterName == hostDomain {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/internal/cloudfront/service_helpers.go
+++ b/internal/cloudfront/service_helpers.go
@@ -30,44 +30,6 @@ import (
 
 const prefixPathType = string(networkingv1.PathTypePrefix)
 
-func newDistribution(ingresses []k8s.CDNIngress, group, webACLARN, distARN string, cfg config.Config) (Distribution, error) {
-	b := NewDistributionBuilder(
-		group,
-		cfg,
-	)
-
-	for _, ing := range ingresses {
-		b = b.WithOrigin(newOrigin(ing, cfg))
-		b = b.WithAlternateDomains(ing.AlternateDomainNames)
-		b = b.AppendTags(ing.Tags)
-		if len(ing.Class.CertificateArn) > 0 && len(cfg.CloudFrontSecurityPolicy) > 0 {
-			b = b.WithTLS(ing.Class.CertificateArn, cfg.CloudFrontSecurityPolicy)
-		}
-	}
-
-	if cfg.CloudFrontEnableIPV6 {
-		b = b.WithIPv6()
-	}
-
-	if cfg.CloudFrontEnableLogging && len(cfg.CloudFrontS3BucketLog) > 0 {
-		b = b.WithLogging(cfg.CloudFrontS3BucketLog, group)
-	}
-
-	if len(cfg.CloudFrontCustomTags) > 0 {
-		b = b.AppendTags(cfg.CloudFrontCustomTags)
-	}
-
-	if len(webACLARN) > 0 {
-		b = b.WithWebACL(webACLARN)
-	}
-
-	if len(distARN) > 0 {
-		b = b.WithARN(distARN)
-	}
-
-	return b.Build()
-}
-
 func renderDescription(template, group string) string {
 	return strings.ReplaceAll(template, "{{group}}", group)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,11 @@ type Config struct {
 	CloudFrontDefaultBucketOriginAccessRequestPolicyID string
 }
 
+// TLSIsEnabled returns whether TLS is enabled
+func (c Config) TLSIsEnabled() bool {
+	return len(c.CloudFrontSecurityPolicy) > 0
+}
+
 // Parse environment variables into a config struct
 func Parse() Config {
 	devMode := viper.GetBool(devModeKey)

--- a/internal/k8s/cdnclass.go
+++ b/internal/k8s/cdnclass.go
@@ -21,8 +21,6 @@ package k8s
 
 // CDNClass represents the domain object
 type CDNClass struct {
-	// CertificateArn of domain name
-	CertificateArn string
 	// HostedZoneID of domain name
 	HostedZoneID string
 	// CreateAlias determine if should create an DNS alias or not

--- a/internal/k8s/ingress_fetcher_v1_test.go
+++ b/internal/k8s/ingress_fetcher_v1_test.go
@@ -56,8 +56,7 @@ type IngressFetcherV1TestSuite struct {
 
 func (s *IngressFetcherV1TestSuite) SetupTest() {
 	s.CDNClass = CDNClass{
-		CertificateArn: "foo",
-		HostedZoneID:   "bar",
+		HostedZoneID: "bar",
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
$TITLE, allowing users to not need to inform one per class. This also allows the same class to potentially be able to use different certs.

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
This requires less input from users and make it more scalable to deploy on multi-cluster/multi-account environments (eg, using the [Landing Zone pattern](https://docs.aws.amazon.com/prescriptive-guidance/latest/migration-aws-environment/understanding-landing-zones.html)), partially eliminating the need for per-account configuration.

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->
Tests + manually validated.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [x] I have updated the documentation accordingly.
