### PR TITLE
[PE1-1809] Support Function Associations for ingress-based behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ In CloudFront, these would result in the following order:
 - `/en-us/foo` -> en-us specific origin
 - `/*/foo` -> catch all origin
 
+// TODO in upcoming PRs
+// document function associations annotation for ingress-based behaviors
+// also document lambda invocation IAM stuff
+
 ## User-supplied origin/behavior configuration
 
 If you need additional origin/behavior configuration that you can't express via Ingress resources (e.g., pointing to an S3 bucket with static resources of your application) you can do that using the `cdn-origin-controller.gympass.com/cf.user-origins`.
@@ -161,6 +165,9 @@ metadata:
           - /bar
           - /bar/*
 ```
+
+// TODO in upcoming PRs
+// document function associations in user origins
 
 The `.host` is the hostname of the origin you're configuring.
 

--- a/controllers/ingress_v1_controller.go
+++ b/controllers/ingress_v1_controller.go
@@ -64,6 +64,11 @@ func (r *V1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		return reconcile.Result{}, fmt.Errorf("could not fetch Ingress: %+v", err)
 	}
 
+	// TODO in upcoming PRs:
+	// validate function associations annotation to ensure:
+	//   a. it only references paths present in this Ingress (this currently silently fails)
+	//   b. do not break any existing rules that are already mapped in fa.Validate() (this currently silently fails)
+
 	cdnClassName := k8s.CDNClassAnnotationValue(ingress)
 	cdnClass, err := r.CDNClassFetcher.FetchByName(ctx, cdnClassName)
 	if err != nil {

--- a/controllers/ingress_v1_controller.go
+++ b/controllers/ingress_v1_controller.go
@@ -70,7 +70,7 @@ func (r *V1Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("could not find CDN class (%s): %v", cdnClassName, err)
 	}
 
-	reconcilingCDNIngress, err := k8s.NewCDNIngressFromV1(ingress, cdnClass)
+	reconcilingCDNIngress, err := k8s.NewCDNIngressFromV1(ctx, ingress, cdnClass)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
 	go.uber.org/zap v1.24.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
@@ -76,7 +77,6 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.27.2 // indirect
 	k8s.io/component-base v0.27.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect

--- a/internal/cloudfront/distribution_test.go
+++ b/internal/cloudfront/distribution_test.go
@@ -118,7 +118,6 @@ func (s *DistributionTestSuite) TestDistributionBuilder_WithDuplicateOrigins() {
 			PathPattern:   path,
 			RequestPolicy: "216adef6-5c7f-47e4-b989-5492eafa07d3",
 			CachePolicy:   "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
-			ViewerFnARN:   "",
 			OriginHost:    "host",
 		}
 	}

--- a/internal/cloudfront/function.go
+++ b/internal/cloudfront/function.go
@@ -39,29 +39,45 @@ type BodyIncluderFunction interface {
 func NewFunctions(fa k8s.FunctionAssociations) []Function {
 	var functions []Function
 	if fa.ViewerRequest != nil {
-		var fn Function = newRequestCloudfrontFunction(fa.ViewerRequest.ARN, cloudfront.EventTypeViewerRequest)
-		if fa.ViewerRequest.FunctionType == k8s.FunctionTypeEdge {
-			fn = newRequestEdgeFunction(fa.ViewerRequest.ARN, cloudfront.EventTypeViewerRequest, fa.ViewerRequest.IncludeBody)
-		}
-		functions = append(functions, fn)
+		functions = append(functions, newViewerRequestFn(fa))
 	}
 	if fa.ViewerResponse != nil {
-		var fn Function = newResponseCloudfrontFunction(fa.ViewerResponse.ARN, cloudfront.EventTypeViewerResponse)
-		if fa.ViewerResponse.FunctionType == k8s.FunctionTypeEdge {
-			fn = newResponseEdgeFunction(fa.ViewerResponse.ARN, cloudfront.EventTypeViewerResponse)
-		}
-		functions = append(functions, fn)
+		functions = append(functions, newViewerResponseFn(fa))
 	}
 	if fa.OriginRequest != nil {
-		fn := newRequestEdgeFunction(fa.OriginRequest.ARN, cloudfront.EventTypeOriginRequest, fa.OriginRequest.IncludeBody)
-		functions = append(functions, fn)
+		functions = append(functions, newOriginRequestFn(fa))
 	}
 	if fa.OriginResponse != nil {
-		fn := newResponseEdgeFunction(fa.OriginResponse.ARN, cloudfront.EventTypeOriginResponse)
-		functions = append(functions, fn)
+		functions = append(functions, newOriginResponseFn(fa))
 	}
 
 	return functions
+}
+
+func newViewerRequestFn(fa k8s.FunctionAssociations) Function {
+	var fn Function = newRequestCloudfrontFunction(fa.ViewerRequest.ARN, cloudfront.EventTypeViewerRequest)
+	if fa.ViewerRequest.FunctionType == k8s.FunctionTypeEdge {
+		fn = newRequestEdgeFunction(fa.ViewerRequest.ARN, cloudfront.EventTypeViewerRequest, fa.ViewerRequest.IncludeBody)
+	}
+	return fn
+}
+
+func newViewerResponseFn(fa k8s.FunctionAssociations) Function {
+	var fn Function = newResponseCloudfrontFunction(fa.ViewerResponse.ARN, cloudfront.EventTypeViewerResponse)
+	if fa.ViewerResponse.FunctionType == k8s.FunctionTypeEdge {
+		fn = newResponseEdgeFunction(fa.ViewerResponse.ARN, cloudfront.EventTypeViewerResponse)
+	}
+	return fn
+}
+
+func newOriginRequestFn(fa k8s.FunctionAssociations) requestEdgeFunction {
+	fn := newRequestEdgeFunction(fa.OriginRequest.ARN, cloudfront.EventTypeOriginRequest, fa.OriginRequest.IncludeBody)
+	return fn
+}
+
+func newOriginResponseFn(fa k8s.FunctionAssociations) responseEdgeFunction {
+	fn := newResponseEdgeFunction(fa.OriginResponse.ARN, cloudfront.EventTypeOriginResponse)
+	return fn
 }
 
 var _ Function = requestCloudfrontFunction{}

--- a/internal/cloudfront/function.go
+++ b/internal/cloudfront/function.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cloudfront
+
+import (
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+
+	"github.com/Gympass/cdn-origin-controller/internal/k8s"
+)
+
+type Function interface {
+	ARN() string
+	Type() k8s.FunctionType
+	EventType() string
+}
+
+type BodyIncluderFunction interface {
+	Function
+	IncludeBody() bool
+}
+
+func NewFunctions(fa k8s.FunctionAssociations) []Function {
+	var functions []Function
+	if fa.ViewerRequest != nil {
+		var fn Function = newRequestCloudfrontFunction(fa.ViewerRequest.ARN, cloudfront.EventTypeViewerRequest)
+		if fa.ViewerRequest.FunctionType == k8s.FunctionTypeEdge {
+			fn = newRequestEdgeFunction(fa.ViewerRequest.ARN, cloudfront.EventTypeViewerRequest, fa.ViewerRequest.IncludeBody)
+		}
+		functions = append(functions, fn)
+	}
+	if fa.ViewerResponse != nil {
+		var fn Function = newResponseCloudfrontFunction(fa.ViewerResponse.ARN, cloudfront.EventTypeViewerResponse)
+		if fa.ViewerResponse.FunctionType == k8s.FunctionTypeEdge {
+			fn = newResponseEdgeFunction(fa.ViewerResponse.ARN, cloudfront.EventTypeViewerResponse)
+		}
+		functions = append(functions, fn)
+	}
+	if fa.OriginRequest != nil {
+		fn := newRequestEdgeFunction(fa.OriginRequest.ARN, cloudfront.EventTypeOriginRequest, fa.OriginRequest.IncludeBody)
+		functions = append(functions, fn)
+	}
+	if fa.OriginResponse != nil {
+		fn := newResponseEdgeFunction(fa.OriginResponse.ARN, cloudfront.EventTypeOriginResponse)
+		functions = append(functions, fn)
+	}
+
+	return functions
+}
+
+var _ Function = requestCloudfrontFunction{}
+
+type requestCloudfrontFunction struct {
+	basicFunction
+}
+
+func newRequestCloudfrontFunction(arn string, eventType string) requestCloudfrontFunction {
+	return requestCloudfrontFunction{
+		basicFunction: newBasicFunction(arn, eventType),
+	}
+}
+
+func (requestCloudfrontFunction) Type() k8s.FunctionType {
+	return k8s.FunctionTypeCloudfront
+}
+
+var _ BodyIncluderFunction = requestEdgeFunction{}
+
+type requestEdgeFunction struct {
+	bodyIncluderFunction
+}
+
+func newRequestEdgeFunction(arn string, eventType string, includeBody bool) requestEdgeFunction {
+	return requestEdgeFunction{
+		bodyIncluderFunction: newBodyIncluderFunction(arn, eventType, includeBody),
+	}
+}
+
+func (requestEdgeFunction) Type() k8s.FunctionType {
+	return k8s.FunctionTypeEdge
+}
+
+var _ Function = responseCloudfrontFunction{}
+
+type responseCloudfrontFunction struct {
+	basicFunction
+}
+
+func newResponseCloudfrontFunction(arn string, eventType string) responseCloudfrontFunction {
+	return responseCloudfrontFunction{
+		basicFunction: newBasicFunction(arn, eventType),
+	}
+}
+
+func (f responseCloudfrontFunction) Type() k8s.FunctionType {
+	return k8s.FunctionTypeCloudfront
+}
+
+var _ Function = responseEdgeFunction{}
+
+type responseEdgeFunction struct {
+	basicFunction
+}
+
+func newResponseEdgeFunction(arn string, eventType string) responseEdgeFunction {
+	return responseEdgeFunction{
+		basicFunction: newBasicFunction(arn, eventType),
+	}
+}
+
+func (responseEdgeFunction) Type() k8s.FunctionType {
+	return k8s.FunctionTypeEdge
+}
+
+type bodyIncluderFunction struct {
+	basicFunction
+	includeBody bool
+}
+
+func newBodyIncluderFunction(arn string, eventType string, includeBody bool) bodyIncluderFunction {
+	return bodyIncluderFunction{
+		basicFunction: newBasicFunction(arn, eventType),
+		includeBody:   includeBody,
+	}
+}
+
+func (f bodyIncluderFunction) IncludeBody() bool {
+	return f.includeBody
+}
+
+type basicFunction struct {
+	arn       string
+	eventType string
+}
+
+func newBasicFunction(arn string, eventType string) basicFunction {
+	return basicFunction{
+		arn:       arn,
+		eventType: eventType,
+	}
+}
+
+func (f basicFunction) ARN() string {
+	return f.arn
+}
+
+func (f basicFunction) EventType() string {
+	return f.eventType
+}

--- a/internal/cloudfront/function_test.go
+++ b/internal/cloudfront/function_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package cloudfront
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Gympass/cdn-origin-controller/internal/k8s"
+)
+
+func TestRunCDNIngressTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &functionTestSuite{})
+}
+
+type functionTestSuite struct {
+	suite.Suite
+}
+
+func (s *functionTestSuite) TestNewFunctions() {
+	fa := k8s.FunctionAssociations{
+		ViewerRequest: &k8s.ViewerRequestFunction{
+			ViewerFunction: k8s.ViewerFunction{
+				ARN:          "viewer-request-arn",
+				FunctionType: k8s.FunctionTypeEdge,
+			},
+			IncludeBody: true,
+		},
+		ViewerResponse: &k8s.ViewerFunction{
+			ARN:          "viewer-response-arn",
+			FunctionType: k8s.FunctionTypeCloudfront,
+		},
+		OriginRequest: &k8s.OriginRequestFunction{
+			OriginFunction: k8s.OriginFunction{
+				ARN: "origin-request-arn",
+			},
+			IncludeBody: false,
+		},
+		OriginResponse: &k8s.OriginFunction{
+			ARN: "origin-response-arn",
+		},
+	}
+
+	expected := []Function{
+		requestEdgeFunction{
+			bodyIncluderFunction: bodyIncluderFunction{
+				basicFunction: basicFunction{
+					arn:       "viewer-request-arn",
+					eventType: cloudfront.EventTypeViewerRequest,
+				},
+				includeBody: true,
+			},
+		},
+		responseCloudfrontFunction{
+			basicFunction: basicFunction{
+				arn:       "viewer-response-arn",
+				eventType: cloudfront.EventTypeViewerResponse,
+			},
+		},
+		requestEdgeFunction{
+			bodyIncluderFunction: bodyIncluderFunction{
+				basicFunction: basicFunction{
+					arn:       "origin-request-arn",
+					eventType: cloudfront.EventTypeOriginRequest,
+				},
+				includeBody: false,
+			},
+		},
+		responseEdgeFunction{
+			basicFunction: basicFunction{
+				arn:       "origin-response-arn",
+				eventType: cloudfront.EventTypeOriginResponse,
+			},
+		},
+	}
+
+	got := NewFunctions(fa)
+
+	s.Equal(expected, got)
+}

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -73,7 +73,6 @@ type Behavior struct {
 // OriginBuilder allows the construction of an Origin
 type OriginBuilder struct {
 	host             string
-	viewerFnARN      string
 	requestPolicy    string
 	distributionName string
 	cachePolicy      string

--- a/internal/k8s/function_association.go
+++ b/internal/k8s/function_association.go
@@ -245,3 +245,14 @@ func functionAssociations(obj client.Object) (map[string]FunctionAssociations, e
 
 	return fa.Paths, nil
 }
+
+func newFAFromViewerFunctionARN(arn string) FunctionAssociations {
+	return FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          arn,
+				FunctionType: FunctionTypeCloudfront,
+			},
+		},
+	}
+}

--- a/internal/k8s/function_association.go
+++ b/internal/k8s/function_association.go
@@ -228,12 +228,7 @@ func (f *OriginRequestFunction) validate() error {
 	if f == nil {
 		return nil
 	}
-
-	if err := f.OriginFunction.validate(); err != nil {
-		return err
-	}
-
-	return nil
+	return f.OriginFunction.validate()
 }
 
 func functionAssociations(obj client.Object) (map[string]FunctionAssociations, error) {

--- a/internal/k8s/function_association.go
+++ b/internal/k8s/function_association.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package k8s
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type FunctionType string
+
+const (
+	FunctionTypeEdge       FunctionType = "edge"
+	FunctionTypeCloudfront FunctionType = "cloudfront"
+)
+
+const (
+	cfFunctionAssociationsAnnotation = "cdn-origin-controller.gympass.com/cf.function-associations"
+)
+
+type FunctionAssociationsPaths struct {
+	Paths map[string]FunctionAssociations `yaml:",inline"`
+}
+
+type FunctionAssociations struct {
+	ViewerRequest  *ViewerRequestFunction `yaml:"viewerRequest"`
+	ViewerResponse *ViewerFunction        `yaml:"viewerResponse"`
+	OriginRequest  *OriginRequestFunction `yaml:"originRequest"`
+	OriginResponse *OriginFunction        `yaml:"originResponse"`
+}
+
+func (fa FunctionAssociations) Validate() error {
+	if err := fa.ViewerRequest.validate(); err != nil {
+		return fmt.Errorf("invalid viewerRequest: %v", err)
+	}
+	if err := fa.ViewerResponse.validate(); err != nil {
+		return fmt.Errorf("invalid viewerResponse: %v", err)
+	}
+	if err := fa.OriginRequest.validate(); err != nil {
+		return fmt.Errorf("invalid originRequest: %v", err)
+	}
+	if err := fa.OriginResponse.validate(); err != nil {
+		return fmt.Errorf("invalid originResponse: %v", err)
+	}
+
+	if !fa.ViewerRequest.isCompatibleWith(fa.ViewerResponse) {
+		return fmt.Errorf(
+			"different function types informed for viewerResponse and viewerRequest. They must be %q only or %q only",
+			FunctionTypeCloudfront, FunctionTypeEdge)
+	}
+
+	return nil
+}
+
+func (fa FunctionAssociations) Merge(other FunctionAssociations) (FunctionAssociations, error) {
+	merged := fa.deepCopy()
+	other = other.deepCopy()
+
+	if fa.ViewerRequest != nil && other.ViewerRequest != nil {
+		if fa.ViewerRequest.ARN != other.ViewerRequest.ARN {
+			return FunctionAssociations{}, fmt.Errorf("viewer request function informed twice with different ARNs")
+		}
+		if fa.ViewerRequest.FunctionType != other.ViewerRequest.FunctionType {
+			return FunctionAssociations{}, fmt.Errorf("viewer request function informed twice with different function types")
+		}
+		if fa.ViewerRequest.IncludeBody != other.ViewerRequest.IncludeBody {
+			return FunctionAssociations{}, fmt.Errorf("viewer request function informed twice with different body inclusion configuration")
+		}
+	} else if other.ViewerRequest != nil {
+		merged.ViewerRequest = other.ViewerRequest
+	}
+
+	if fa.ViewerResponse != nil && other.ViewerResponse != nil {
+		if fa.ViewerResponse.ARN != other.ViewerResponse.ARN {
+			return FunctionAssociations{}, fmt.Errorf("viewer response function informed twice with different ARNs")
+		}
+		if fa.ViewerResponse.FunctionType != other.ViewerResponse.FunctionType {
+			return FunctionAssociations{}, fmt.Errorf("viewer response function informed twice with different function types")
+		}
+	} else if other.ViewerResponse != nil {
+		merged.ViewerResponse = other.ViewerResponse
+	}
+
+	if fa.OriginRequest != nil && other.OriginRequest != nil {
+		if fa.OriginRequest.ARN != other.OriginRequest.ARN {
+			return FunctionAssociations{}, fmt.Errorf("origin request function informed twice with different ARNs")
+		}
+		if fa.OriginRequest.IncludeBody != other.OriginRequest.IncludeBody {
+			return FunctionAssociations{}, fmt.Errorf("origin request function informed twice with different body inclusion configuration")
+		}
+	} else if other.OriginRequest != nil {
+		merged.OriginRequest = other.OriginRequest
+	}
+
+	if fa.OriginResponse != nil && other.OriginResponse != nil {
+		if fa.OriginResponse.ARN != other.OriginResponse.ARN {
+			return FunctionAssociations{}, fmt.Errorf("origin response function informed twice with different ARNs")
+		}
+	} else if other.OriginResponse != nil {
+		merged.OriginResponse = other.OriginResponse
+	}
+
+	return merged, nil
+}
+
+func (fa FunctionAssociations) deepCopy() FunctionAssociations {
+	copied := FunctionAssociations{}
+	if fa.ViewerRequest != nil {
+		copied.ViewerRequest = &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          fa.ViewerRequest.ARN,
+				FunctionType: fa.ViewerRequest.FunctionType,
+			},
+			IncludeBody: fa.ViewerRequest.IncludeBody,
+		}
+	}
+	if fa.ViewerResponse != nil {
+		copied.ViewerResponse = &ViewerFunction{
+			ARN:          fa.ViewerResponse.ARN,
+			FunctionType: fa.ViewerResponse.FunctionType,
+		}
+	}
+
+	if fa.OriginRequest != nil {
+		copied.OriginRequest = &OriginRequestFunction{
+			OriginFunction: OriginFunction{ARN: fa.OriginRequest.ARN},
+			IncludeBody:    fa.OriginRequest.IncludeBody,
+		}
+	}
+	if fa.OriginResponse != nil {
+		copied.OriginResponse = &OriginFunction{ARN: fa.OriginResponse.ARN}
+	}
+
+	return copied
+}
+
+type ViewerFunction struct {
+	ARN          string       `yaml:"arn"`
+	FunctionType FunctionType `yaml:"functionType"`
+}
+
+func (f *ViewerFunction) validate() error {
+	if f == nil {
+		return nil
+	}
+
+	if len(f.ARN) == 0 {
+		return errors.New("function arn must be informed")
+	}
+
+	if f.FunctionType != FunctionTypeEdge && f.FunctionType != FunctionTypeCloudfront {
+		return fmt.Errorf("invalid function type: %q", f.FunctionType)
+	}
+
+	return nil
+}
+
+type ViewerRequestFunction struct {
+	ViewerFunction `yaml:",inline"`
+	IncludeBody    bool `yaml:"includeBody"`
+}
+
+func (f *ViewerRequestFunction) validate() error {
+	if f == nil {
+		return nil
+	}
+
+	if err := f.ViewerFunction.validate(); err != nil {
+		return err
+	}
+
+	if f.ViewerFunction.FunctionType == FunctionTypeCloudfront && f.IncludeBody {
+		return fmt.Errorf("includeBody is only supported for functionType %q", FunctionTypeEdge)
+	}
+
+	return nil
+}
+
+func (f *ViewerRequestFunction) isCompatibleWith(response *ViewerFunction) bool {
+	if f == nil || response == nil {
+		return true
+	}
+	return f.FunctionType == response.FunctionType
+}
+
+type OriginFunction struct {
+	ARN string `yaml:"arn"`
+}
+
+func (f *OriginFunction) validate() error {
+	if f == nil {
+		return nil
+	}
+
+	if len(f.ARN) == 0 {
+		return errors.New("function arn must be informed")
+	}
+
+	return nil
+}
+
+type OriginRequestFunction struct {
+	OriginFunction `yaml:",inline"`
+	IncludeBody    bool `yaml:"includeBody"`
+}
+
+func (f *OriginRequestFunction) validate() error {
+	if f == nil {
+		return nil
+	}
+
+	if err := f.OriginFunction.validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func functionAssociations(obj client.Object) (map[string]FunctionAssociations, error) {
+	faYAML, ok := obj.GetAnnotations()[cfFunctionAssociationsAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	fa := FunctionAssociationsPaths{}
+	err := yaml.Unmarshal([]byte(faYAML), &fa)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling YAML: %v", err)
+	}
+
+	return fa.Paths, nil
+}

--- a/internal/k8s/function_association_test.go
+++ b/internal/k8s/function_association_test.go
@@ -1,0 +1,616 @@
+// Copyright (c) 2023 GPBR Participacoes LTDA.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRunFunctionAssociationsSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &functionAssociationsTestSuite{})
+}
+
+type functionAssociationsTestSuite struct {
+	suite.Suite
+}
+
+func (s *functionAssociationsTestSuite) Test_functionAssociations_Valid() {
+	yaml := `
+/foo/*:
+  viewerRequest:
+    arn: arn:aws:cloudfront::000000000000:function/test-function-associations
+    functionType: cloudfront
+  viewerResponse:
+    arn: arn:aws:cloudfront::000000000000:function/test-function-associations
+    functionType: cloudfront
+  originRequest:
+    arn: arn:aws:lambda:us-east-1:000000000000:function:test-function-associations
+    includeBody: true
+  originResponse:
+    arn: arn:aws:lambda:us-east-1:000000000000:function:test-function-associations
+/bar:
+  viewerRequest:
+    arn: arn:aws:cloudfront::000000000000:function/test-function-associations
+    functionType: cloudfront
+`
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				cfFunctionAssociationsAnnotation: yaml,
+			},
+		},
+	}
+
+	got, err := functionAssociations(ing)
+
+	s.NoError(err)
+	s.Equal(map[string]FunctionAssociations{
+		"/foo/*": {
+			ViewerRequest: &ViewerRequestFunction{
+				ViewerFunction: ViewerFunction{
+					ARN:          "arn:aws:cloudfront::000000000000:function/test-function-associations",
+					FunctionType: FunctionTypeCloudfront,
+				},
+			},
+			ViewerResponse: &ViewerFunction{
+				ARN:          "arn:aws:cloudfront::000000000000:function/test-function-associations",
+				FunctionType: FunctionTypeCloudfront,
+			},
+			OriginRequest: &OriginRequestFunction{
+				OriginFunction: OriginFunction{
+					ARN: "arn:aws:lambda:us-east-1:000000000000:function:test-function-associations",
+				},
+				IncludeBody: true,
+			},
+			OriginResponse: &OriginFunction{
+				ARN: "arn:aws:lambda:us-east-1:000000000000:function:test-function-associations",
+			},
+		},
+		"/bar": {
+			ViewerRequest: &ViewerRequestFunction{
+				ViewerFunction: ViewerFunction{
+					ARN:          "arn:aws:cloudfront::000000000000:function/test-function-associations",
+					FunctionType: FunctionTypeCloudfront,
+				},
+			},
+		},
+	}, got)
+}
+
+func (s *functionAssociationsTestSuite) Test_functionAssociations_InvalidYAML() {
+	yaml := `	foo`
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				cfFunctionAssociationsAnnotation: yaml,
+			},
+		},
+	}
+
+	got, err := functionAssociations(ing)
+
+	s.Error(err)
+	s.Nil(got)
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Validate_ValidFunctions() {
+	testCases := []struct {
+		name  string
+		input FunctionAssociations
+	}{
+		{
+			name:  "nil functions are valid",
+			input: FunctionAssociations{},
+		},
+		{
+			name: "properly filled functions are valid",
+			input: FunctionAssociations{
+				ViewerRequest: &ViewerRequestFunction{
+					IncludeBody: false,
+					ViewerFunction: ViewerFunction{
+						ARN:          "some-arn",
+						FunctionType: FunctionTypeCloudfront,
+					}},
+				ViewerResponse: &ViewerFunction{
+					ARN:          "some-arn",
+					FunctionType: FunctionTypeCloudfront,
+				},
+				OriginRequest: &OriginRequestFunction{
+					IncludeBody: true,
+					OriginFunction: OriginFunction{
+						ARN: "some-other-arn",
+					}},
+				OriginResponse: &OriginFunction{
+					ARN: "some-arn",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.NoErrorf(tc.input.Validate(), "test case: %s", tc.name)
+	}
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Validate_DifferentFunctionTypesOnViewerIsInvalid() {
+	fa := FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{ViewerFunction: ViewerFunction{
+			ARN:          "some-arn",
+			FunctionType: FunctionTypeCloudfront,
+		}},
+		ViewerResponse: &ViewerFunction{
+			ARN:          "another-arn",
+			FunctionType: FunctionTypeEdge,
+		},
+	}
+
+	s.Error(fa.Validate())
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Validate_IncludeBodyForCloudfrontFunctionIsInvalid() {
+	fa := FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeCloudfront,
+			},
+			IncludeBody: true,
+		},
+	}
+
+	s.Error(fa.Validate())
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Validate_IncludeBodyForEdgeFunctionIsValid() {
+	fa := FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeEdge,
+			},
+			IncludeBody: true,
+		},
+		OriginRequest: &OriginRequestFunction{
+			OriginFunction: OriginFunction{
+				ARN: "another-arn",
+			},
+			IncludeBody: true,
+		},
+	}
+
+	s.NoError(fa.Validate())
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Validate_InvalidFunctionType() {
+	testCases := []struct {
+		name  string
+		input FunctionAssociations
+	}{
+		{
+			name: "on viewerRequest",
+			input: FunctionAssociations{
+				ViewerRequest: &ViewerRequestFunction{ViewerFunction: ViewerFunction{
+					ARN:          "some-arn",
+					FunctionType: "not-a-valid-function-type",
+				}},
+			},
+		},
+		{
+			name: "on viewerResponse",
+			input: FunctionAssociations{
+				ViewerResponse: &ViewerFunction{
+					ARN:          "some-arn",
+					FunctionType: "not-a-valid-function-type",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Errorf(tc.input.Validate(), "test case: %v", tc.name)
+	}
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Validate_NoARNIsInvalid() {
+	testCases := []struct {
+		name  string
+		input FunctionAssociations
+	}{
+		{
+			name: "on viewerRequest",
+			input: FunctionAssociations{
+				ViewerRequest: &ViewerRequestFunction{
+					ViewerFunction: ViewerFunction{
+						FunctionType: FunctionTypeEdge,
+					},
+					IncludeBody: true,
+				},
+			},
+		},
+		{
+			name: "on viewerResponse",
+			input: FunctionAssociations{
+				ViewerResponse: &ViewerFunction{
+					FunctionType: FunctionTypeCloudfront,
+				},
+			},
+		},
+		{
+			name: "on originRequest",
+			input: FunctionAssociations{
+				OriginRequest: &OriginRequestFunction{},
+			},
+		},
+		{
+			name: "on originResponse",
+			input: FunctionAssociations{
+				OriginResponse: &OriginFunction{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Errorf(tc.input.Validate(), "test case: %v", tc.name)
+	}
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_ChangingMergedFADoesNotChangeOriginalOrInput() {
+	original := FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeCloudfront,
+			},
+		},
+		ViewerResponse: &ViewerFunction{
+			ARN:          "some-arn",
+			FunctionType: FunctionTypeCloudfront,
+		},
+	}
+
+	input := FunctionAssociations{
+		OriginRequest: &OriginRequestFunction{
+			OriginFunction: OriginFunction{
+				ARN: "some-arn",
+			},
+			IncludeBody: true,
+		},
+	}
+
+	merged, err := original.Merge(input)
+	s.NoError(err)
+
+	merged.ViewerRequest.ViewerFunction.ARN = "some-other-arn"
+	merged.ViewerResponse.ARN = "some-other-arn"
+
+	s.Equal(FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeCloudfront,
+			},
+		},
+		ViewerResponse: &ViewerFunction{
+			ARN:          "some-arn",
+			FunctionType: FunctionTypeCloudfront,
+		},
+	}, original)
+	s.Equal(FunctionAssociations{
+		OriginRequest: &OriginRequestFunction{
+			OriginFunction: OriginFunction{
+				ARN: "some-arn",
+			},
+			IncludeBody: true,
+		},
+	}, input)
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_OriginalIsEmptyAndAbleToMerge() {
+	originalFa := FunctionAssociations{}
+	mergingFa := FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeCloudfront,
+			},
+		},
+		ViewerResponse: &ViewerFunction{
+			ARN:          "some-arn",
+			FunctionType: FunctionTypeCloudfront,
+		},
+		OriginRequest: &OriginRequestFunction{
+			IncludeBody: true,
+			OriginFunction: OriginFunction{
+				ARN: "another-arn",
+			},
+		},
+		OriginResponse: &OriginFunction{
+			ARN: "another-arn",
+		},
+	}
+
+	got, err := originalFa.Merge(mergingFa)
+
+	s.NoError(err)
+
+	s.Equal("some-arn", got.ViewerRequest.ViewerFunction.ARN)
+	s.Equal(FunctionTypeCloudfront, got.ViewerRequest.ViewerFunction.FunctionType)
+
+	s.Equal("some-arn", got.ViewerResponse.ARN)
+	s.Equal(FunctionTypeCloudfront, got.ViewerResponse.FunctionType)
+
+	s.Equal("another-arn", got.OriginRequest.OriginFunction.ARN)
+	s.True(got.OriginRequest.IncludeBody)
+
+	s.Equal("another-arn", got.OriginResponse.ARN)
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_MergingIsEmptyAndAbleToMerge() {
+	originalFa := FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeCloudfront,
+			},
+		},
+		ViewerResponse: &ViewerFunction{
+			ARN:          "some-arn",
+			FunctionType: FunctionTypeCloudfront,
+		},
+		OriginRequest: &OriginRequestFunction{
+			IncludeBody: true,
+			OriginFunction: OriginFunction{
+				ARN: "another-arn",
+			},
+		},
+		OriginResponse: &OriginFunction{
+			ARN: "another-arn",
+		},
+	}
+	mergingFa := FunctionAssociations{}
+
+	got, err := originalFa.Merge(mergingFa)
+
+	s.NoError(err)
+
+	s.Equal("some-arn", got.ViewerRequest.ViewerFunction.ARN)
+	s.Equal(FunctionTypeCloudfront, got.ViewerRequest.ViewerFunction.FunctionType)
+
+	s.Equal("some-arn", got.ViewerResponse.ARN)
+	s.Equal(FunctionTypeCloudfront, got.ViewerResponse.FunctionType)
+
+	s.Equal("another-arn", got.OriginRequest.OriginFunction.ARN)
+	s.True(got.OriginRequest.IncludeBody)
+
+	s.Equal("another-arn", got.OriginResponse.ARN)
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_NeitherIsEmptyButAreAbleToMerge() {
+	originalFa := FunctionAssociations{
+		ViewerRequest: &ViewerRequestFunction{
+			ViewerFunction: ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeCloudfront,
+			},
+		},
+		ViewerResponse: &ViewerFunction{
+			ARN:          "some-arn",
+			FunctionType: FunctionTypeCloudfront,
+		},
+	}
+	mergingFa := FunctionAssociations{
+		OriginRequest: &OriginRequestFunction{
+			IncludeBody: true,
+			OriginFunction: OriginFunction{
+				ARN: "another-arn",
+			},
+		},
+		OriginResponse: &OriginFunction{
+			ARN: "another-arn",
+		},
+	}
+
+	got, err := originalFa.Merge(mergingFa)
+
+	s.NoError(err)
+
+	s.Equal("some-arn", got.ViewerRequest.ViewerFunction.ARN)
+	s.Equal(FunctionTypeCloudfront, got.ViewerRequest.ViewerFunction.FunctionType)
+
+	s.Equal("some-arn", got.ViewerResponse.ARN)
+	s.Equal(FunctionTypeCloudfront, got.ViewerResponse.FunctionType)
+
+	s.Equal("another-arn", got.OriginRequest.OriginFunction.ARN)
+	s.True(got.OriginRequest.IncludeBody)
+
+	s.Equal("another-arn", got.OriginResponse.ARN)
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_ConflictingViewerRequest() {
+	originalFn := &ViewerRequestFunction{
+		ViewerFunction: ViewerFunction{
+			ARN:          "some-arn",
+			FunctionType: FunctionTypeEdge,
+		},
+		IncludeBody: true,
+	}
+
+	testCases := []struct {
+		name string
+		fn   *ViewerRequestFunction
+	}{
+		{
+			name: "ARN is different",
+			fn: &ViewerRequestFunction{
+				ViewerFunction: ViewerFunction{
+					ARN:          "some-other-arn",
+					FunctionType: FunctionTypeEdge,
+				},
+				IncludeBody: true,
+			},
+		},
+		{
+			name: "FunctionType is different",
+			fn: &ViewerRequestFunction{
+				ViewerFunction: ViewerFunction{
+					ARN:          "some-arn",
+					FunctionType: FunctionTypeCloudfront,
+				},
+				IncludeBody: true,
+			},
+		},
+		{
+			name: "IncludeBody is different",
+			fn: &ViewerRequestFunction{
+				ViewerFunction: ViewerFunction{
+					ARN:          "some-arn",
+					FunctionType: FunctionTypeEdge,
+				},
+				IncludeBody: false,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		originalFa := FunctionAssociations{
+			ViewerRequest: originalFn,
+		}
+		mergingFa := FunctionAssociations{
+			ViewerRequest: tc.fn,
+		}
+
+		merged, err := originalFa.Merge(mergingFa)
+
+		s.Errorf(err, "test case: %s", tc.name)
+		s.Emptyf(merged, "test case: %s", tc.name)
+	}
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_ConflictingViewerResponse() {
+	originalFn := &ViewerFunction{
+		ARN:          "some-arn",
+		FunctionType: FunctionTypeCloudfront,
+	}
+
+	testCases := []struct {
+		name string
+		fn   *ViewerFunction
+	}{
+		{
+			name: "ARN is different",
+			fn: &ViewerFunction{
+				ARN:          "some-other-arn",
+				FunctionType: FunctionTypeCloudfront,
+			},
+		},
+		{
+			name: "FunctionType is different",
+			fn: &ViewerFunction{
+				ARN:          "some-arn",
+				FunctionType: FunctionTypeEdge,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		originalFa := FunctionAssociations{
+			ViewerResponse: originalFn,
+		}
+		mergingFa := FunctionAssociations{
+			ViewerResponse: tc.fn,
+		}
+
+		merged, err := originalFa.Merge(mergingFa)
+
+		s.Errorf(err, "test case: %s", tc.name)
+		s.Emptyf(merged, "test case: %s", tc.name)
+	}
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_ConflictingOriginRequest() {
+	originalFn := &OriginRequestFunction{
+		OriginFunction: OriginFunction{
+			ARN: "some-arn",
+		},
+		IncludeBody: true,
+	}
+
+	testCases := []struct {
+		name string
+		fn   *OriginRequestFunction
+	}{
+		{
+			name: "ARN is different",
+			fn: &OriginRequestFunction{
+				OriginFunction: OriginFunction{
+					ARN: "some-other-arn",
+				},
+				IncludeBody: true,
+			},
+		},
+		{
+			name: "IncludeBody is different",
+			fn: &OriginRequestFunction{
+				OriginFunction: OriginFunction{
+					ARN: "some-arn",
+				},
+				IncludeBody: false,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		originalFa := FunctionAssociations{
+			OriginRequest: originalFn,
+		}
+		mergingFa := FunctionAssociations{
+			OriginRequest: tc.fn,
+		}
+
+		merged, err := originalFa.Merge(mergingFa)
+
+		s.Errorf(err, "test case: %s", tc.name)
+		s.Emptyf(merged, "test case: %s", tc.name)
+	}
+}
+
+func (s *functionAssociationsTestSuite) TestFunctionAssociations_Merge_ConflictingOriginResponse() {
+	originalFa := FunctionAssociations{
+		OriginResponse: &OriginFunction{
+			ARN: "some-arn",
+		},
+	}
+
+	mergingFa := FunctionAssociations{
+		OriginResponse: &OriginFunction{
+			ARN: "some-other-arn",
+		},
+	}
+
+	merged, err := originalFa.Merge(mergingFa)
+
+	s.Error(err)
+	s.Empty(merged)
+}

--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -20,6 +20,8 @@
 package k8s
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,9 +29,9 @@ import (
 	"gopkg.in/yaml.v3"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Gympass/cdn-origin-controller/internal/strhelper"
 )
@@ -53,8 +55,9 @@ const (
 
 // Path represents a path item within an Ingress
 type Path struct {
-	PathPattern string
-	PathType    string
+	PathPattern          string
+	PathType             string
+	FunctionAssociations FunctionAssociations
 }
 
 // CDNIngress represents an Ingress within the bounded context of cdn-origin-controller
@@ -62,13 +65,13 @@ type CDNIngress struct {
 	types.NamespacedName
 	LoadBalancerHost     string
 	Group                string
-	Paths                []Path
+	UnmergedPaths        []Path
 	ViewerFnARN          string
 	OriginReqPolicy      string
 	CachePolicy          string
 	OriginRespTimeout    int64
 	AlternateDomainNames []string
-	WebACLARN            string
+	UnmergedWebACLARN    string
 	IsBeingRemoved       bool
 	OriginAccess         string
 	Class                CDNClass
@@ -85,31 +88,128 @@ func (c CDNIngress) GetName() string {
 	return c.Name
 }
 
+var (
+	errSharedParamsConflictingACL   = errors.New("conflicting WAF WebACL ARNs")
+	errSharedParamsConflictingPaths = errors.New("conflicting path configuration")
+)
+
 // SharedIngressParams represents parameters which might be specified in multiple Ingresses
 type SharedIngressParams struct {
 	WebACLARN string
+	paths     map[types.NamespacedName][]Path
 }
 
 // NewSharedIngressParams creates a new SharedIngressParams from a slice of CDNIngress
 func NewSharedIngressParams(ingresses []CDNIngress) (SharedIngressParams, error) {
+	acl, err := mergedWebACL(ingresses)
+	if err != nil {
+		return SharedIngressParams{}, fmt.Errorf("%w: %v", errSharedParamsConflictingACL, err)
+	}
+
+	fa, err := mergedPaths(ingresses)
+	if err != nil {
+		return SharedIngressParams{}, fmt.Errorf("%w: %v", errSharedParamsConflictingPaths, err)
+	}
+
+	return SharedIngressParams{
+		WebACLARN: acl,
+		paths:     fa,
+	}, nil
+}
+
+func (sp SharedIngressParams) PathsFromIngress(ing types.NamespacedName) []Path {
+	var paths []Path
+	for _, p := range sp.paths[ing] {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+func mergedPaths(ingresses []CDNIngress) (map[types.NamespacedName][]Path, error) {
+	// Let's put it all in a map of Paths to easily check if we already saw this
+	// Path before and whether to merge it, but we must avoid checking equality of
+	// Paths by also checking Path.FunctionAssociations, because the same Path might
+	// be specified in more than one CDNIngress (and should be merged if valid).
+	//
+	// This is why here we always assign a new Path when indexing the map,
+	// instead of just using the input Path, with an empty FunctionAssociations.
+	// This way we ensure we only check equality via PathPattern and PathType.
+	//
+	// We're also going to create a map[ingressNamespacedName] because this
+	// struct will later also need to filter paths by Ingress, so it comes in handy
+	// to filter easily.
+	//
+	// The resulting map of all of this is a map of Path indexed by ingress name.
+
+	mergedPaths := make(map[types.NamespacedName]map[Path]FunctionAssociations)
+	for _, ing := range ingresses {
+		_, ok := mergedPaths[ing.NamespacedName]
+		if !ok {
+			mergedPaths[ing.NamespacedName] = make(map[Path]FunctionAssociations)
+		}
+
+		for _, p := range ing.UnmergedPaths {
+			pKey := Path{
+				PathPattern: p.PathPattern,
+				PathType:    p.PathType,
+			}
+			existingFA, ok := mergedPaths[ing.NamespacedName][pKey]
+			if !ok {
+				mergedPaths[ing.NamespacedName][pKey] = p.FunctionAssociations
+				continue
+			}
+
+			mergedFA, err := existingFA.Merge(p.FunctionAssociations)
+			if err != nil {
+				return nil, fmt.Errorf("conflicting function associations on %q: %v", p.PathPattern, err)
+			}
+
+			mergedPaths[ing.NamespacedName][pKey] = mergedFA
+		}
+	}
+
+	return mapOfNamespacedNameToPath(mergedPaths), nil
+}
+
+func mapOfNamespacedNameToPath(ingsPathsAndFAs map[types.NamespacedName]map[Path]FunctionAssociations) map[types.NamespacedName][]Path {
+	s := make(map[types.NamespacedName][]Path)
+	for ing, pathsAndFAs := range ingsPathsAndFAs {
+		for p, fa := range pathsAndFAs {
+			path := Path{
+				PathPattern:          p.PathPattern,
+				PathType:             p.PathType,
+				FunctionAssociations: fa,
+			}
+			s[ing] = append(s[ing], path)
+		}
+	}
+	return s
+}
+
+func mergedWebACL(ingresses []CDNIngress) (string, error) {
 	webACLARNs := sets.NewString()
 	for _, ing := range ingresses {
-		if len(ing.WebACLARN) > 0 {
-			webACLARNs.Insert(ing.WebACLARN)
+		if len(ing.UnmergedWebACLARN) > 0 {
+			webACLARNs.Insert(ing.UnmergedWebACLARN)
 		}
 	}
 
 	if len(webACLARNs) > 1 {
-		return SharedIngressParams{}, fmt.Errorf("conflicting WAF WebACL ARNs: %v", webACLARNs.List())
+		return "", fmt.Errorf("more than one ACL specified: %v", webACLARNs.List())
 	}
 
 	validARN, _ := webACLARNs.PopAny()
-	return SharedIngressParams{WebACLARN: validARN}, nil
+	return validARN, nil
 }
 
 // NewCDNIngressFromV1 creates a new CDNIngress from a v1 Ingress
-func NewCDNIngressFromV1(ing *networkingv1.Ingress, class CDNClass) (CDNIngress, error) {
+func NewCDNIngressFromV1(ctx context.Context, ing *networkingv1.Ingress, class CDNClass) (CDNIngress, error) {
 	tags, err := tagsAnnotationValue(ing)
+	if err != nil {
+		return CDNIngress{}, err
+	}
+
+	paths, err := pathsV1(ctx, ing)
 	if err != nil {
 		return CDNIngress{}, err
 	}
@@ -120,13 +220,13 @@ func NewCDNIngressFromV1(ing *networkingv1.Ingress, class CDNClass) (CDNIngress,
 			Name:      ing.Name,
 		},
 		Group:                groupAnnotationValue(ing),
-		Paths:                pathsV1(ing.Spec.Rules),
+		UnmergedPaths:        paths,
 		ViewerFnARN:          viewerFnARN(ing),
 		OriginReqPolicy:      originReqPolicy(ing),
 		CachePolicy:          cachePolicy(ing),
 		OriginRespTimeout:    originRespTimeout(ing),
 		AlternateDomainNames: alternateDomainNames(ing),
-		WebACLARN:            webACLARN(ing),
+		UnmergedWebACLARN:    webACLARN(ing),
 		IsBeingRemoved:       IsBeingRemovedFromDesiredState(ing),
 		Class:                class,
 		Tags:                 tags,
@@ -140,7 +240,14 @@ func NewCDNIngressFromV1(ing *networkingv1.Ingress, class CDNClass) (CDNIngress,
 	return result, nil
 }
 
-func pathsV1(rules []networkingv1.IngressRule) []Path {
+func pathsV1(ctx context.Context, ing *networkingv1.Ingress) ([]Path, error) {
+	fa, err := functionAssociations(ing)
+	if err != nil {
+		return nil, fmt.Errorf("parsing function associations from annotation: %v", err)
+	}
+
+	rules := ing.Spec.Rules
+
 	var paths []Path
 	for _, rule := range rules {
 		for _, p := range rule.HTTP.Paths {
@@ -148,10 +255,22 @@ func pathsV1(rules []networkingv1.IngressRule) []Path {
 				PathPattern: p.Path,
 				PathType:    string(*p.PathType),
 			}
+
+			if err := fa[p.Path].Validate(); err != nil {
+				log.FromContext(ctx).Info(
+					"Found invalid function association when calculating desired state",
+					"functionAssociation", fa[p.Path],
+					"invalidIngress", ing.Namespace+"/"+ing.Name)
+			} else {
+				// ignore invalid FAs for now, don't halt reconciliation of all Ingresses because one of them is bad
+				// the bad ingress should throw an error when reconciled due to invalid annotation
+				newPath.FunctionAssociations = fa[p.Path]
+			}
+
 			paths = append(paths, newPath)
 		}
 	}
-	return paths
+	return paths, nil
 }
 
 func viewerFnARN(obj client.Object) string {

--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -118,11 +118,7 @@ func NewSharedIngressParams(ingresses []CDNIngress) (SharedIngressParams, error)
 }
 
 func (sp SharedIngressParams) PathsFromIngress(ing types.NamespacedName) []Path {
-	var paths []Path
-	for _, p := range sp.paths[ing] {
-		paths = append(paths, p)
-	}
-	return paths
+	return sp.paths[ing]
 }
 
 func mergedPaths(ingresses []CDNIngress) (map[types.NamespacedName][]Path, error) {

--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -282,13 +282,14 @@ func pathsForFunctionAssociations(ctx context.Context, ing *networkingv1.Ingress
 			}
 
 			if err := fa[p.Path].Validate(); err != nil {
-				log.FromContext(ctx).Info(
+				// complain about invalid FAs for now, but don't halt reconciliation of all Ingresses because one of them is bad
+				// the bad ingress itself will throw an error when reconciled due to invalid annotation
+				log.FromContext(ctx).Error(
+					errors.New("invalid function association"),
 					"Found invalid function association when calculating desired state",
 					"functionAssociation", fa[p.Path],
 					"invalidIngress", ing.Namespace+"/"+ing.Name)
 			} else {
-				// ignore invalid FAs for now, don't halt reconciliation of all Ingresses because one of them is bad
-				// the bad ingress should throw an error when reconciled due to invalid annotation
 				newPath.FunctionAssociations = fa[p.Path]
 			}
 

--- a/internal/k8s/ingress_fetcher_v1.go
+++ b/internal/k8s/ingress_fetcher_v1.go
@@ -44,7 +44,7 @@ func (i ingFetcherV1) FetchBy(ctx context.Context, cdnClass CDNClass, predicate 
 
 	var result []CDNIngress
 	for _, k8sIng := range list.Items {
-		ing, err := NewCDNIngressFromV1(&k8sIng, cdnClass)
+		ing, err := NewCDNIngressFromV1(ctx, &k8sIng, cdnClass)
 		if err != nil {
 			return []CDNIngress{}, err
 		}

--- a/internal/k8s/ingress_fetcher_v1_test.go
+++ b/internal/k8s/ingress_fetcher_v1_test.go
@@ -153,7 +153,6 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 					LoadBalancerHost:  "host",
 					UnmergedPaths:     []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginRespTimeout: int64(35),
-					ViewerFnARN:       "foo",
 					OriginReqPolicy:   "None",
 					OriginAccess:      "Public",
 				},
@@ -179,7 +178,6 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 					LoadBalancerHost: "host",
 					UnmergedPaths:    []Path{{PathPattern: "/foo"}},
 					OriginReqPolicy:  "None",
-					ViewerFnARN:      "foo",
 					OriginAccess:     "Bucket",
 				},
 				{

--- a/internal/k8s/ingress_fetcher_v1_test.go
+++ b/internal/k8s/ingress_fetcher_v1_test.go
@@ -113,7 +113,7 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 					NamespacedName:   types.NamespacedName{Name: "name", Namespace: "namespace"},
 					Group:            "group",
 					LoadBalancerHost: "host",
-					Paths:            []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					UnmergedPaths:    []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginAccess:     "Public",
 				},
 			},
@@ -131,7 +131,7 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 					NamespacedName:   types.NamespacedName{Name: "name", Namespace: "namespace"},
 					Group:            "group",
 					LoadBalancerHost: "host",
-					Paths:            []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					UnmergedPaths:    []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginAccess:     "Bucket",
 				},
 			},
@@ -151,7 +151,7 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 					NamespacedName:    types.NamespacedName{Name: "name", Namespace: "namespace"},
 					Group:             "group",
 					LoadBalancerHost:  "host",
-					Paths:             []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					UnmergedPaths:     []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginRespTimeout: int64(35),
 					ViewerFnARN:       "foo",
 					OriginReqPolicy:   "None",
@@ -177,7 +177,7 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 					NamespacedName:   types.NamespacedName{Name: "name", Namespace: "namespace"},
 					Group:            "group",
 					LoadBalancerHost: "host",
-					Paths:            []Path{{PathPattern: "/foo"}},
+					UnmergedPaths:    []Path{{PathPattern: "/foo"}},
 					OriginReqPolicy:  "None",
 					ViewerFnARN:      "foo",
 					OriginAccess:     "Bucket",
@@ -186,7 +186,7 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 					NamespacedName:    types.NamespacedName{Name: "name", Namespace: "namespace"},
 					Group:             "group",
 					LoadBalancerHost:  "host",
-					Paths:             []Path{{PathPattern: "/bar"}},
+					UnmergedPaths:     []Path{{PathPattern: "/bar"}},
 					OriginRespTimeout: int64(35),
 					OriginAccess:      "Public",
 				},
@@ -211,7 +211,7 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
 			return ing.Group == "group"
 		}
 
-		expectedParentCDNIng, err := NewCDNIngressFromV1(parentIng, s.CDNClass)
+		expectedParentCDNIng, err := NewCDNIngressFromV1(context.Background(), parentIng, s.CDNClass)
 		s.NoError(err, "test: %s", tc.name)
 
 		expectedIngs := append(tc.expectedIngs, expectedParentCDNIng)

--- a/internal/k8s/user_origin.go
+++ b/internal/k8s/user_origin.go
@@ -53,12 +53,12 @@ func cdnIngressesForUserOrigins(obj client.Object) ([]CDNIngress, error) {
 			NamespacedName:    types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()},
 			LoadBalancerHost:  o.Host,
 			Group:             groupAnnotationValue(obj),
-			Paths:             o.paths(),
+			UnmergedPaths:     o.paths(),
 			ViewerFnARN:       o.ViewerFunctionARN,
 			OriginReqPolicy:   o.RequestPolicy,
 			CachePolicy:       o.CachePolicy,
 			OriginRespTimeout: o.ResponseTimeout,
-			WebACLARN:         o.WebACLARN,
+			UnmergedWebACLARN: o.WebACLARN,
 			OriginAccess:      o.OriginAccess,
 		}
 		result = append(result, ing)
@@ -66,6 +66,11 @@ func cdnIngressesForUserOrigins(obj client.Object) ([]CDNIngress, error) {
 
 	return result, nil
 }
+
+// TODO in upcoming PRs:
+// parse and validate function associations, ensuring:
+//   a. it only references paths present in this custom origin
+//   b. do not break any existing rules that are already mapped in fa.Validate()
 
 type userOrigin struct {
 	Host              string   `yaml:"host"`

--- a/internal/k8s/user_origin.go
+++ b/internal/k8s/user_origin.go
@@ -54,7 +54,6 @@ func cdnIngressesForUserOrigins(obj client.Object) ([]CDNIngress, error) {
 			LoadBalancerHost:  o.Host,
 			Group:             groupAnnotationValue(obj),
 			UnmergedPaths:     o.paths(),
-			ViewerFnARN:       o.ViewerFunctionARN,
 			OriginReqPolicy:   o.RequestPolicy,
 			CachePolicy:       o.CachePolicy,
 			OriginRespTimeout: o.ResponseTimeout,

--- a/internal/k8s/user_origin_test.go
+++ b/internal/k8s/user_origin_test.go
@@ -57,7 +57,7 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 				{
 					Group:            "group",
 					LoadBalancerHost: "foo.com",
-					Paths:            []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					UnmergedPaths:    []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginAccess:     "Public",
 				},
 			},
@@ -74,7 +74,7 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 				{
 					Group:            "group",
 					LoadBalancerHost: "foo.com",
-					Paths:            []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					UnmergedPaths:    []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginAccess:     "Bucket",
 				},
 			},
@@ -93,7 +93,7 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 				{
 					Group:             "group",
 					LoadBalancerHost:  "foo.com",
-					Paths:             []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					UnmergedPaths:     []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginRespTimeout: int64(35),
 					ViewerFnARN:       "foo",
 					OriginReqPolicy:   "None",
@@ -118,7 +118,7 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 				{
 					Group:            "group",
 					LoadBalancerHost: "foo.com",
-					Paths:            []Path{{PathPattern: "/foo"}},
+					UnmergedPaths:    []Path{{PathPattern: "/foo"}},
 					OriginReqPolicy:  "None",
 					ViewerFnARN:      "foo",
 					OriginAccess:     "Bucket",
@@ -126,7 +126,7 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 				{
 					Group:             "group",
 					LoadBalancerHost:  "bar.com",
-					Paths:             []Path{{PathPattern: "/bar"}},
+					UnmergedPaths:     []Path{{PathPattern: "/bar"}},
 					OriginRespTimeout: int64(35),
 					OriginAccess:      "Public",
 				},

--- a/internal/k8s/user_origin_test.go
+++ b/internal/k8s/user_origin_test.go
@@ -95,7 +95,6 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 					LoadBalancerHost:  "foo.com",
 					UnmergedPaths:     []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginRespTimeout: int64(35),
-					ViewerFnARN:       "foo",
 					OriginReqPolicy:   "None",
 					OriginAccess:      "Public",
 				},
@@ -120,7 +119,6 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 					LoadBalancerHost: "foo.com",
 					UnmergedPaths:    []Path{{PathPattern: "/foo"}},
 					OriginReqPolicy:  "None",
-					ViewerFnARN:      "foo",
 					OriginAccess:     "Bucket",
 				},
 				{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
- $TITLE
- deprecate viewer function arn annotation in favor of more flexible function associations annotation

TODO in upcoming PRs:
- [x] implement the same feature for custom user origins
  - #106 
- [x] implement validation regarding function associations of the ingress being reconciled
  - #107 
- [ ] documentation

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->

This allows users to specify both [Cloudfront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html) and [Lambda@Edge Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-the-edge.html) that should be associated with behaviors present in the distribution.

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->

Created, updated and deleted functions from a Distribution based on multiple Ingresses.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [ ] I have updated the documentation accordingly.
