### PR TITLE
[PE1-1809] feat(k8s): support function-associations for user-origins

### DIFF
--- a/internal/cloudfront/service.go
+++ b/internal/cloudfront/service.go
@@ -140,7 +140,7 @@ func (s *Service) desiredIngresses(ctx context.Context, reconciling k8s.CDNIngre
 func (s *Service) isPartOfDesiredState(reconciling k8s.CDNIngress) func(k8s.CDNIngress) bool {
 	return func(ing k8s.CDNIngress) bool {
 		isPartOfGroup := ing.Group == reconciling.Group
-		hasBeenProvisioned := len(ing.LoadBalancerHost) > 0
+		hasBeenProvisioned := len(ing.OriginHost) > 0
 		return !ing.IsBeingRemoved && isPartOfGroup && hasBeenProvisioned
 	}
 }

--- a/internal/cloudfront/service_helpers.go
+++ b/internal/cloudfront/service_helpers.go
@@ -35,12 +35,12 @@ func renderDescription(template, group string) string {
 }
 
 func newOrigin(ing k8s.CDNIngress, cfg config.Config, shared k8s.SharedIngressParams) Origin {
-	builder := NewOriginBuilder(ing.Group, ing.LoadBalancerHost, ing.OriginAccess, cfg).
+	builder := NewOriginBuilder(ing.Group, ing.OriginHost, ing.OriginAccess, cfg).
 		WithResponseTimeout(ing.OriginRespTimeout).
 		WithRequestPolicy(ing.OriginReqPolicy).
 		WithCachePolicy(ing.CachePolicy)
 
-	for _, p := range shared.PathsFromIngress(ing.NamespacedName) {
+	for _, p := range shared.PathsFromOrigin(ing.OriginHost) {
 		for _, pp := range pathPatternsForPath(p) {
 			builder = builder.WithBehavior(pp, NewFunctions(p.FunctionAssociations)...)
 		}

--- a/internal/k8s/function_association.go
+++ b/internal/k8s/function_association.go
@@ -154,6 +154,13 @@ func (fa FunctionAssociations) deepCopy() FunctionAssociations {
 	return copied
 }
 
+func (fa FunctionAssociations) IsEmpty() bool {
+	return fa.ViewerRequest == nil &&
+		fa.ViewerResponse == nil &&
+		fa.OriginRequest == nil &&
+		fa.OriginResponse == nil
+}
+
 type ViewerFunction struct {
 	ARN          string       `yaml:"arn"`
 	FunctionType FunctionType `yaml:"functionType"`

--- a/internal/k8s/ingress_fetcher_v1_test.go
+++ b/internal/k8s/ingress_fetcher_v1_test.go
@@ -110,11 +110,11 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
                                     - /foo/*`,
 			expectedIngs: []CDNIngress{
 				{
-					NamespacedName:   types.NamespacedName{Name: "name", Namespace: "namespace"},
-					Group:            "group",
-					LoadBalancerHost: "host",
-					UnmergedPaths:    []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
-					OriginAccess:     "Public",
+					NamespacedName: types.NamespacedName{Name: "name", Namespace: "namespace"},
+					Group:          "group",
+					OriginHost:     "host",
+					UnmergedPaths:  []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					OriginAccess:   "Public",
 				},
 			},
 		},
@@ -128,11 +128,11 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
                                   originAccess: Bucket`,
 			expectedIngs: []CDNIngress{
 				{
-					NamespacedName:   types.NamespacedName{Name: "name", Namespace: "namespace"},
-					Group:            "group",
-					LoadBalancerHost: "host",
-					UnmergedPaths:    []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
-					OriginAccess:     "Bucket",
+					NamespacedName: types.NamespacedName{Name: "name", Namespace: "namespace"},
+					Group:          "group",
+					OriginHost:     "host",
+					UnmergedPaths:  []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
+					OriginAccess:   "Bucket",
 				},
 			},
 		},
@@ -144,13 +144,12 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
                                   paths:
                                     - /foo
                                     - /foo/*
-                                  viewerFunctionARN: foo
                                   originRequestPolicy: None`,
 			expectedIngs: []CDNIngress{
 				{
 					NamespacedName:    types.NamespacedName{Name: "name", Namespace: "namespace"},
 					Group:             "group",
-					LoadBalancerHost:  "host",
+					OriginHost:        "host",
 					UnmergedPaths:     []Path{{PathPattern: "/foo"}, {PathPattern: "/foo/*"}},
 					OriginRespTimeout: int64(35),
 					OriginReqPolicy:   "None",
@@ -164,7 +163,6 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
                                 - host: host
                                   paths:
                                     - /foo
-                                  viewerFunctionARN: foo
                                   originRequestPolicy: None
                                   originAccess: Bucket
                                 - host: host
@@ -173,17 +171,17 @@ func (s *IngressFetcherV1TestSuite) TestFetchBy_SuccessWithUserOrigins() {
                                     - /bar`,
 			expectedIngs: []CDNIngress{
 				{
-					NamespacedName:   types.NamespacedName{Name: "name", Namespace: "namespace"},
-					Group:            "group",
-					LoadBalancerHost: "host",
-					UnmergedPaths:    []Path{{PathPattern: "/foo"}},
-					OriginReqPolicy:  "None",
-					OriginAccess:     "Bucket",
+					NamespacedName:  types.NamespacedName{Name: "name", Namespace: "namespace"},
+					Group:           "group",
+					OriginHost:      "host",
+					UnmergedPaths:   []Path{{PathPattern: "/foo"}},
+					OriginReqPolicy: "None",
+					OriginAccess:    "Bucket",
 				},
 				{
 					NamespacedName:    types.NamespacedName{Name: "name", Namespace: "namespace"},
 					Group:             "group",
-					LoadBalancerHost:  "host",
+					OriginHost:        "host",
 					UnmergedPaths:     []Path{{PathPattern: "/bar"}},
 					OriginRespTimeout: int64(35),
 					OriginAccess:      "Public",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
Depends on #105.

- $TITLE
- `CDNIngress` now maintains a map of `[]Path` indexed by origin host
  - previously it was indexed by Ingress namespaced name, but that's no longer a unique key when dealing with user origins

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
Refer to #105

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->

Created, updated and deleted functions from a Distribution based on multiple user-origins.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [ ] I have updated the documentation accordingly.
