### PR TITLE
fix(webacl-conflicts): [PE1-4466] Fixing panic when there's no distARN to be reconciled

### DIFF
--- a/internal/cloudfront/service.go
+++ b/internal/cloudfront/service.go
@@ -247,7 +247,7 @@ func (s *Service) newDistribution(ingresses []k8s.CDNIngress, group string, shar
 
 	if len(shared.WebACLARN) > 0 {
 		b = b.WithWebACL(shared.WebACLARN)
-	} else {
+	} else if len(distARN) > 0 {
 		b, err = s.keepCurrentWebACLConfig(b, distARN)
 		if err != nil {
 			return Distribution{}, fmt.Errorf("setting webacl config: %v", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
<!--- Describe your changes -->
Related to https://github.com/gympass/cdn-origin-controller/pull/124 
Fixing panic on keepCurrentWebACLConfig when there's no distribution ARN to be reconciled.

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
[PE1-4466](https://gympass.atlassian.net/browse/PE1-4466)

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->
Automated tests + manual validation

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have implemented automated tests for the changes.
- [x] I have updated the documentation accordingly.


[PE1-4466]: https://gympass.atlassian.net/browse/PE1-4466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ