### PR TITLE
fix: ensure refreshed eTag before update distribution

### DIFF
--- a/internal/cloudfront/repository.go
+++ b/internal/cloudfront/repository.go
@@ -153,14 +153,21 @@ func (r DistRepository) Sync(d Distribution) (Distribution, error) {
 		}
 	})
 
-	config.SetCallerReference(*output.DistributionConfig.CallerReference)
-	config.SetDefaultRootObject(*output.DistributionConfig.DefaultRootObject)
-	config.SetCustomErrorResponses(output.DistributionConfig.CustomErrorResponses)
-	config.SetRestrictions(output.DistributionConfig.Restrictions)
+	// Fetch a fresh ETag right before updating to avoid PreconditionFailed errors
+	// caused by the ETag becoming stale during OAC sync operations.
+	freshOutput, err := r.DistributionConfigByID(d.ID)
+	if err != nil {
+		return Distribution{}, fmt.Errorf("getting fresh distribution config for update: %v", err)
+	}
+
+	config.SetCallerReference(*freshOutput.DistributionConfig.CallerReference)
+	config.SetDefaultRootObject(*freshOutput.DistributionConfig.DefaultRootObject)
+	config.SetCustomErrorResponses(freshOutput.DistributionConfig.CustomErrorResponses)
+	config.SetRestrictions(freshOutput.DistributionConfig.Restrictions)
 
 	updateInput := &awscloudfront.UpdateDistributionInput{
 		DistributionConfig: config,
-		IfMatch:            output.ETag,
+		IfMatch:            freshOutput.ETag,
 		Id:                 aws.String(d.ID),
 	}
 

--- a/internal/cloudfront/repository_test.go
+++ b/internal/cloudfront/repository_test.go
@@ -305,6 +305,7 @@ func (s *DistributionRepositoryTestSuite) TestSync_CantUpdateDistribution() {
 
 	var noError error
 	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
+	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("UpdateDistribution", mock.Anything).Return(errors.New("mock err")).Once()
 
 	repo := DistRepository{
@@ -335,6 +336,7 @@ func (s *DistributionRepositoryTestSuite) TestSync_CantSaveTags() {
 	}
 
 	var noError error
+	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("UpdateDistribution", mock.Anything).Return(noError).Once()
 	s.cfClient.On("TagResource", mock.Anything).Return(errors.New("mock err")).Once()
@@ -373,6 +375,7 @@ func (s *DistributionRepositoryTestSuite) TestSync_OriginDoesNotExistYet() {
 	}
 
 	var noError error
+	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("UpdateDistribution", mock.Anything).Return(noError).Once()
 	s.cfClient.On("TagResource", mock.Anything).Return(noError).Once()
@@ -425,6 +428,7 @@ func (s *DistributionRepositoryTestSuite) TestSync_OriginAlreadyExists() {
 	}
 
 	var noError error
+	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("UpdateDistribution", mock.Anything).Return(noError).Once()
 	s.cfClient.On("TagResource", mock.Anything).Return(noError).Once()
@@ -524,6 +528,7 @@ func (s *DistributionRepositoryTestSuite) TestSync_BehaviorDoesNotExistYet() {
 	var noError error
 
 	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
+	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("UpdateDistribution", mock.Anything).Return(noError).Once()
 	s.cfClient.On("TagResource", mock.Anything).Return(noError).Once()
 
@@ -604,6 +609,7 @@ func (s *DistributionRepositoryTestSuite) TestSync_BehaviorAlreadyExists() {
 
 	var noError error
 	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
+	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("UpdateDistribution", mock.Anything).Return(noError).Once()
 	s.cfClient.On("TagResource", mock.Anything).Return(noError).Once()
 
@@ -662,6 +668,7 @@ func (s *DistributionRepositoryTestSuite) TestUpdate_ShouldSyncOneOACAndDeleteOn
 	}
 
 	var noError error
+	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("GetDistributionConfig", mock.Anything).Return(noError).Once()
 	s.cfClient.On("UpdateDistribution", mock.Anything).Return(noError).Once()
 	s.cfClient.On("TagResource", mock.Anything).Return(noError).Once()


### PR DESCRIPTION
This pull request addresses an issue with stale ETags during CloudFront distribution sync operations and updates related tests to match the new behavior. The main change ensures that a fresh ETag is always fetched before updating a distribution to avoid `PreconditionFailed` errors. The test suite has been updated to reflect the additional call to fetch the latest distribution configuration.

**CloudFront Distribution Sync Improvements:**

* In `internal/cloudfront/repository.go`, the `Sync` method now fetches a fresh distribution configuration and ETag immediately before updating, preventing `PreconditionFailed` errors caused by stale ETags during OAC sync operations.

**Test Suite Updates:**

* Updated multiple test cases in `internal/cloudfront/repository_test.go` to expect an additional call to `GetDistributionConfig`, reflecting the new logic that fetches a fresh ETag before updating:
  - `TestSync_CantUpdateDistribution`
  - `TestSync_CantSaveTags`
  - `TestSync_OriginDoesNotExistYet`
  - `TestSync_OriginAlreadyExists`
  - `TestSync_BehaviorDoesNotExistYet`
  - `TestSync_BehaviorAlreadyExists`
  - `TestUpdate_ShouldSyncOneOACAndDeleteOn`