### PR TITLE
feat(cloudfront): add response policy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following annotation controls how origins and behaviors are attached to Clou
 - `cdn-origin-controller.gympass.com/cf.alternate-domain-names`: a comma-separated list of alternate domains to be configured on the CloudFront distribution. Duplicates on the same or different Ingress resources from the same group cause no harm. Example: `alias1.foo,alias2.foo`
 - `cdn-origin-controller.gympass.com/cf.origin-request-policy`: the ID of the origin request policy that should be associated with the behaviors defined by the Ingress resource. Defaults to the ID of the AWS pre-defined policy "Managed-AllViewer" (ID: 216adef6-5c7f-47e4-b989-5492eafa07d3) for Public origins, and "Managed-CORS-S3Origin" (ID: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf) for Bucket origins, however these defaults can be overriden through configuration by setting the `CF_DEFAULT_PUBLIC_ORIGIN_ACCESS_REQUEST_POLICY_ID` or `CF_DEFAULT_PUBLIC_ORIGIN_ACCESS_REQUEST_POLICY_ID` environment variables. If set to`"None"` no policy will be associated.
 - `cdn-origin-controller.gympass.com/cf.cache-policy`: the ID of the cache policy that should be associated with the behaviors defined by the Ingress resource. Defaults to the ID of the AWS pre-defined policy "CachingDisabled" (ID: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad), this default can be overriden by setting the `CF_DEFAULT_CACHE_REQUEST_POLICY_ID` environment variable. More details about managed cache policies [see](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html).
+- `cdn-origin-controller.gympass.com/cf.response-policy`: the ID of the response headers policy that should be associated with the behaviors defined by the Ingress resource. No policy is associated by default. If set to `"None"` no policy will be associated. More details about managed response headers policies [see](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html).
 - `cdn-origin-controller.gympass.com/cf.origin-response-timeout`: the number of seconds that CloudFront waits for a response from the origin, from 1 to 60. Example: `"30"`
 - `cdn-origin-controller.gympass.com/cf.function-associations`: configures Function Association to behaviors defined as Ingress paths. Refer to the [dedicated section](#function-associations) for details.
 - `cdn-origin-controller.gympass.com/cf.viewer-function-arn`: deprecated in favor of the more generic `cdn-origin-controller.gympass.com/cf.function-associations`, and will be removed at a later release.
@@ -242,6 +243,7 @@ metadata:
       - host: bar.com
         originAccess: Public
         originRequestPolicy: None
+        responsePolicy: 67f7725c-6f97-4210-82d7-5512b31e9d03
         webACLARN: "arn:aws:wafv2:us-east-1:123456789012:global/webacl/ExampleWebACL/473e64fd-f30b-4765-81a0-62ad96dd167a"
         behaviors:
           - path: /bar
@@ -273,6 +275,7 @@ The table below maps remaining available fields of an entry in this list to an a
 | .responseTimeout     | cdn-origin-controller.gympass.com/cf.origin-response-timeout | -                                                                            |
 | .viewerFunctionARN   | cdn-origin-controller.gympass.com/cf.viewer-function-arn     | deprecated, prefer defining associtions in .behaviors[].functionAssociations |
 | .cachePolicy         | cdn-origin-controller.gympass.com/cf.cache-policy            | -                                                                            |
+| .responsePolicy      | cdn-origin-controller.gympass.com/cf.response-policy         | -                                                                            |
 | .webACLARN           | cdn-origin-controller.gympass.com/cf.web-acl-arn             | -                                                                            |
 | .headers             | cdn-origin-controller.gympass.com/cf.origin-headers          | -                                                                            |
 

--- a/internal/cloudfront/aws_models.go
+++ b/internal/cloudfront/aws_models.go
@@ -253,5 +253,9 @@ func baseCacheBehavior(b Behavior) *cloudfront.CacheBehavior {
 		cb.OriginRequestPolicyId = nil
 	}
 
+	if len(b.ResponsePolicy) > 0 && b.ResponsePolicy != "None" {
+		cb.ResponseHeadersPolicyId = aws.String(b.ResponsePolicy)
+	}
+
 	return cb
 }

--- a/internal/cloudfront/origin.go
+++ b/internal/cloudfront/origin.go
@@ -103,6 +103,8 @@ type Behavior struct {
 	RequestPolicy string
 	// CachePolicy is the ID of the cache policy to be associated with this Behavior
 	CachePolicy string
+	// ResponsePolicy is the ID of the response headers policy to be associated with this Behavior
+	ResponsePolicy string
 	// OriginHost the origin's host this behavior belongs to
 	OriginHost string
 	// FunctionAssociations is a slice of Function that should be bound to this Behavior
@@ -116,6 +118,7 @@ type OriginBuilder struct {
 	requestPolicy    string
 	distributionName string
 	cachePolicy      string
+	responsePolicy   string
 	respTimeout      int64
 	accessType       string
 	behaviors        map[string][]Function
@@ -170,6 +173,14 @@ func (b OriginBuilder) WithCachePolicy(policy string) OriginBuilder {
 	return b
 }
 
+// WithResponsePolicy associates a given response headers policy ID with all Behaviors in the Origin being built
+func (b OriginBuilder) WithResponsePolicy(policy string) OriginBuilder {
+	if len(policy) > 0 {
+		b.responsePolicy = policy
+	}
+	return b
+}
+
 // WithResponseTimeout associates a custom response timeout to custom origin
 func (b OriginBuilder) WithResponseTimeout(rpTimeout int64) OriginBuilder {
 	if rpTimeout > 0 {
@@ -197,6 +208,7 @@ func (b OriginBuilder) Build() Origin {
 
 	origin = b.addCachePolicyBehaviors(origin)
 	origin = b.addRequestPolicyToBehaviors(origin)
+	origin = b.addResponsePolicyToBehaviors(origin)
 
 	origin.Access = b.accessType
 
@@ -222,6 +234,13 @@ func (b OriginBuilder) addRequestPolicyToBehaviors(origin Origin) Origin {
 func (b OriginBuilder) addCachePolicyBehaviors(origin Origin) Origin {
 	for i := range origin.Behaviors {
 		origin.Behaviors[i].CachePolicy = b.cachePolicy
+	}
+	return origin
+}
+
+func (b OriginBuilder) addResponsePolicyToBehaviors(origin Origin) Origin {
+	for i := range origin.Behaviors {
+		origin.Behaviors[i].ResponsePolicy = b.responsePolicy
 	}
 	return origin
 }

--- a/internal/cloudfront/origin_test.go
+++ b/internal/cloudfront/origin_test.go
@@ -127,6 +127,25 @@ func (s *OriginTestSuite) TestNewOriginBuilder_WithRequestPolicy() {
 	s.Equal("some-policy", o.Behaviors[1].RequestPolicy)
 }
 
+func (s *OriginTestSuite) TestNewOriginBuilder_WithResponsePolicy() {
+	o := NewOriginBuilder("dist", "origin", "Public", s.cfg).
+		WithBehavior("/").
+		WithBehavior("/foo").
+		WithResponsePolicy("some-response-policy").
+		Build()
+	s.Equal("origin", o.Host)
+	s.Len(o.Behaviors, 2)
+	s.Equal("some-response-policy", o.Behaviors[0].ResponsePolicy)
+	s.Equal("some-response-policy", o.Behaviors[1].ResponsePolicy)
+}
+
+func (s *OriginTestSuite) TestNewOriginBuilder_ResponsePolicyDefaultsToEmpty() {
+	o := NewOriginBuilder("dist", "origin", "Public", s.cfg).
+		WithBehavior("/").
+		Build()
+	s.Empty(o.Behaviors[0].ResponsePolicy)
+}
+
 func (s *OriginTestSuite) TestNewOriginBuilder_WithBucketType() {
 	o := NewOriginBuilder("dist", "origin", "Bucket", s.cfg).
 		Build()

--- a/internal/cloudfront/repository_test.go
+++ b/internal/cloudfront/repository_test.go
@@ -1074,3 +1074,35 @@ func (s *DistributionRepositoryTestSuite) Test_baseCacheBehavior_PolicySetToNone
 	)
 	s.Nil(cb.OriginRequestPolicyId)
 }
+
+func (s *DistributionRepositoryTestSuite) Test_baseCacheBehavior_ResponsePolicySet() {
+	cb := baseCacheBehavior(
+		Behavior{
+			OriginHost:     "host",
+			PathPattern:    "path",
+			ResponsePolicy: "67f7725c-6f97-4210-82d7-5512b31e9d03",
+		},
+	)
+	s.Equal("67f7725c-6f97-4210-82d7-5512b31e9d03", *cb.ResponseHeadersPolicyId)
+}
+
+func (s *DistributionRepositoryTestSuite) Test_baseCacheBehavior_ResponsePolicySetToNone() {
+	cb := baseCacheBehavior(
+		Behavior{
+			OriginHost:     "host",
+			PathPattern:    "path",
+			ResponsePolicy: "None",
+		},
+	)
+	s.Nil(cb.ResponseHeadersPolicyId)
+}
+
+func (s *DistributionRepositoryTestSuite) Test_baseCacheBehavior_ResponsePolicyEmpty() {
+	cb := baseCacheBehavior(
+		Behavior{
+			OriginHost:  "host",
+			PathPattern: "path",
+		},
+	)
+	s.Nil(cb.ResponseHeadersPolicyId)
+}

--- a/internal/cloudfront/service_helpers.go
+++ b/internal/cloudfront/service_helpers.go
@@ -39,6 +39,7 @@ func newOrigin(ing k8s.CDNIngress, cfg config.Config, shared k8s.SharedIngressPa
 		WithResponseTimeout(ing.OriginRespTimeout).
 		WithRequestPolicy(ing.OriginReqPolicy).
 		WithCachePolicy(ing.CachePolicy).
+		WithResponsePolicy(ing.ResponsePolicy).
 		WithOriginHeaders(ing.OriginHeaders)
 
 	for _, p := range shared.PathsFromOrigin(ing.OriginHost) {

--- a/internal/k8s/ingress.go
+++ b/internal/k8s/ingress.go
@@ -47,6 +47,7 @@ const (
 	cfViewerFnAnnotation             = "cdn-origin-controller.gympass.com/cf.viewer-function-arn"
 	cfOrigReqPolicyAnnotation        = "cdn-origin-controller.gympass.com/cf.origin-request-policy"
 	cfCachePolicyAnnotation          = "cdn-origin-controller.gympass.com/cf.cache-policy"
+	cfResponsePolicyAnnotation       = "cdn-origin-controller.gympass.com/cf.response-policy"
 	cfOrigRespTimeoutAnnotation      = "cdn-origin-controller.gympass.com/cf.origin-response-timeout"
 	cfAlternateDomainNamesAnnotation = "cdn-origin-controller.gympass.com/cf.alternate-domain-names"
 	cfWebACLARNAnnotation            = "cdn-origin-controller.gympass.com/cf.web-acl-arn"
@@ -70,6 +71,7 @@ type CDNIngress struct {
 	OriginReqPolicy      string
 	OriginHeaders        map[string]string
 	CachePolicy          string
+	ResponsePolicy       string
 	OriginRespTimeout    int64
 	AlternateDomainNames []string
 	UnmergedWebACLARN    string
@@ -226,6 +228,7 @@ func NewCDNIngressFromV1(ctx context.Context, ing *networkingv1.Ingress, class C
 		OriginReqPolicy:      originReqPolicy(ing),
 		OriginHeaders:        headers,
 		CachePolicy:          cachePolicy(ing),
+		ResponsePolicy:       responsePolicy(ing),
 		OriginRespTimeout:    originRespTimeout(ing),
 		AlternateDomainNames: alternateDomainNames(ing),
 		UnmergedWebACLARN:    webACLARN(ing),
@@ -363,6 +366,10 @@ func originReqPolicy(obj client.Object) string {
 
 func cachePolicy(obj client.Object) string {
 	return obj.GetAnnotations()[cfCachePolicyAnnotation]
+}
+
+func responsePolicy(obj client.Object) string {
+	return obj.GetAnnotations()[cfResponsePolicyAnnotation]
 }
 
 func groupAnnotationValue(obj client.Object) string {

--- a/internal/k8s/user_origin.go
+++ b/internal/k8s/user_origin.go
@@ -60,6 +60,7 @@ func cdnIngressesForUserOrigins(obj client.Object) ([]CDNIngress, error) {
 			UnmergedPaths:     o.paths(),
 			OriginReqPolicy:   o.RequestPolicy,
 			CachePolicy:       o.CachePolicy,
+			ResponsePolicy:    o.ResponsePolicy,
 			OriginRespTimeout: o.ResponseTimeout,
 			UnmergedWebACLARN: o.WebACLARN,
 			OriginAccess:      o.OriginAccess,
@@ -79,6 +80,7 @@ type userOrigin struct {
 	ViewerFunctionARN string                 `yaml:"viewerFunctionARN"` // deprecated in favor of Behaviors
 	RequestPolicy     string                 `yaml:"originRequestPolicy"`
 	CachePolicy       string                 `yaml:"cachePolicy"`
+	ResponsePolicy    string                 `yaml:"responsePolicy"`
 	WebACLARN         string                 `yaml:"webACLARN"`
 	OriginAccess      string                 `yaml:"originAccess" default:"Public"`
 }

--- a/internal/k8s/user_origin_test.go
+++ b/internal/k8s/user_origin_test.go
@@ -100,6 +100,23 @@ func (s *userOriginSuite) Test_cdnIngressesForUserOrigins_Success() {
 			},
 		},
 		{
+			name: "Has a single user origin with response policy",
+			annotationValue: `
+                                - host: foo.com
+                                  paths:
+                                    - /foo
+                                  responsePolicy: 67f7725c-6f97-4210-82d7-5512b31e9d03`,
+			expectedIngs: []CDNIngress{
+				{
+					Group:          "group",
+					OriginHost:     "foo.com",
+					UnmergedPaths:  []Path{{PathPattern: "/foo"}},
+					ResponsePolicy: "67f7725c-6f97-4210-82d7-5512b31e9d03",
+					OriginAccess:   "Public",
+				},
+			},
+		},
+		{
 			name: "Has multiple user origins",
 			annotationValue: `
                                 - host: foo.com


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If this PR is associated with a github issue, the above Title should start with the issue number, eg: PE1-000 Issue summary -->

## Description
Adds CloudFront response headers policy configuration.

## Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If no issue link is provided, then explain why is this change required? What problem does it solve? -->
Allow users to set the response headers policy of the origins of their CloudFront.

## How has this been tested?
<!--- Please describe how you tested your changes, and how they can be tested by reviewers. -->
<!--- If the changes are untested, please explicitly say so and explain why. -->
`go test`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have implemented automated tests for the changes.
- [X] I have updated the documentation accordingly.
